### PR TITLE
Improving uft test discovery and execution (#195)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@
 		<dependency>
 			<artifactId>mqm-rest-client</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.3</version>
+			<version>1.4.1</version>
 		</dependency>
 
 		<!-- org.jenkins-ci.main -->

--- a/src/main/java/com/hp/application/automation/tools/octane/actions/UFTTestDetectionBuildAction.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/actions/UFTTestDetectionBuildAction.java
@@ -87,6 +87,24 @@ public class UFTTestDetectionBuildAction implements Action {
         return results.getUpdatedTests().size() > 0;
     }
 
+    /**
+     * used by ~\src\main\resources\com\hp\application\automation\tools\octane\actions\UFTTestDetectionBuildAction\index.jelly
+     *
+     * @return
+     */
+    public boolean getHasNewScmResources() {
+        return results.getNewScmResourceFiles().size() > 0;
+    }
+
+    /**
+     * used by ~\src\main\resources\com\hp\application\automation\tools\octane\actions\UFTTestDetectionBuildAction\index.jelly
+     *
+     * @return
+     */
+    public boolean getHasDeletedScmResources() {
+        return results.getDeletedScmResourceFiles().size() > 0;
+    }
+
     public void setResults(UFTTestDetectionResult results) {
         this.results = results;
     }

--- a/src/main/java/com/hp/application/automation/tools/octane/actions/UFTTestDetectionPublisher.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/actions/UFTTestDetectionPublisher.java
@@ -47,30 +47,33 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Post-build action of Uft test detection
+ */
 public class UFTTestDetectionPublisher extends Recorder {
 
 	private final String workspaceName;
-	private final String scmResourceId;
+	private final String scmRepositoryId;
 
 	public String getWorkspaceName() {
 		return workspaceName;
 	}
 
-	public String getScmResourceId() {
-		return scmResourceId;
+	public String getScmRepositoryId() {
+		return scmRepositoryId;
 	}
 
 	// Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
 	@DataBoundConstructor
-	public UFTTestDetectionPublisher(String workspaceName, String scmResourceId) {
+	public UFTTestDetectionPublisher(String workspaceName, String scmRepositoryId) {
 
 		this.workspaceName = workspaceName;
-		this.scmResourceId = scmResourceId;
+		this.scmRepositoryId = scmRepositoryId;
 	}
 
 	@Override
 	public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-		UFTTestDetectionResult results = UFTTestDetectionService.startScanning(build, getWorkspaceName(), getScmResourceId(), listener);
+		UFTTestDetectionResult results = UFTTestDetectionService.startScanning(build, getWorkspaceName(), getScmRepositoryId(), listener);
 		UFTTestDetectionBuildAction buildAction = new UFTTestDetectionBuildAction(build, results);
 		build.addAction(buildAction);
 

--- a/src/main/java/com/hp/application/automation/tools/octane/actions/UFTTestUtil.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/actions/UFTTestUtil.java
@@ -41,8 +41,13 @@ public class UFTTestUtil {
      * @return test description
      */
     public static String getTestDescription(FilePath dirPath) {
-        String desc = null;
+        String desc;
+
         try {
+            if(!dirPath.exists()){
+                return  null;
+            }
+
             FilePath tspTestFile = new FilePath(dirPath, "Test.tsp");
             InputStream is = new FileInputStream(tspTestFile.getRemote());
             String xmlContent = decodeXmlContent(is);

--- a/src/main/java/com/hp/application/automation/tools/octane/actions/dto/AutomatedTest.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/actions/dto/AutomatedTest.java
@@ -21,18 +21,16 @@ import com.hp.application.automation.tools.octane.actions.UftTestType;
 import javax.xml.bind.annotation.*;
 
 /**
- * Created by kashbi on 25/09/2016.
+ * This file represents automated test for sending to Octane
  */
-@XmlRootElement(name="test")
+@XmlRootElement(name = "test")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class AutomatedTest {
 
     @XmlTransient
     private Long id;
     @XmlTransient
-    private String type = "test";
-    @XmlTransient
-    private String subtype = "test_automated";
+    private String type = "test_automated";
     @XmlTransient
     private ListNodeEntity testingToolType;
     @XmlTransient
@@ -48,6 +46,8 @@ public class AutomatedTest {
     private String name;
     @XmlAttribute
     private String packageName;
+    @XmlAttribute
+    private Boolean executable;
 
     private String description;
 
@@ -68,14 +68,6 @@ public class AutomatedTest {
 
     public void setType(String type) {
         this.type = type;
-    }
-
-    public String getSubtype() {
-        return subtype;
-    }
-
-    public void setSubtype(String subtype) {
-        this.subtype = subtype;
     }
 
     public ListNodeEntity getFramework() {
@@ -140,5 +132,13 @@ public class AutomatedTest {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public Boolean getExecutable() {
+        return executable;
+    }
+
+    public void setExecutable(Boolean executable) {
+        this.executable = executable;
     }
 }

--- a/src/main/java/com/hp/application/automation/tools/octane/actions/dto/ScmResourceFile.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/actions/dto/ScmResourceFile.java
@@ -1,0 +1,88 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hp.application.automation.tools.octane.actions.dto;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * This file represents scm resource for sending to Octane
+ */
+@XmlRootElement(name="dataTable")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ScmResourceFile {
+
+    @XmlTransient
+    private Long id;
+    @XmlTransient
+    private String type = "scm_resource_file";
+    @XmlTransient
+    private BaseRefEntity scmRepository;
+
+    private String name;
+
+    private String relativePath;
+
+    private String relativePathPrevious;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getRelativePath() {
+        return relativePath;
+    }
+
+    public void setRelativePath(String relativePath) {
+        this.relativePath = relativePath;
+    }
+
+    public String getRelativePathPrevious() {
+        return relativePathPrevious;
+    }
+
+    public void setRelativePathPrevious(String relativePathPrevious) {
+        this.relativePathPrevious = relativePathPrevious;
+    }
+
+    public BaseRefEntity getScmRepository() {
+        return scmRepository;
+    }
+
+    public void setScmRepository(BaseRefEntity scmRepository) {
+        this.scmRepository = scmRepository;
+    }
+}

--- a/src/main/java/com/hp/application/automation/tools/octane/actions/dto/ScmResources.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/actions/dto/ScmResources.java
@@ -1,0 +1,43 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hp.application.automation.tools.octane.actions.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * This file represents collection of scm resources for sending to Octane
+ */
+public class ScmResources {
+
+    private List<ScmResourceFile> data = new ArrayList<>();
+
+    public static ScmResources createWithItems(Collection<ScmResourceFile> resources) {
+        ScmResources result = new ScmResources();
+        result.setData(new ArrayList<>(resources));
+        return result;
+    }
+
+    public List<ScmResourceFile> getData() {
+        return data;
+    }
+
+    public void setData(List<ScmResourceFile> data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/hp/application/automation/tools/octane/configuration/ConfigurationService.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/configuration/ConfigurationService.java
@@ -16,35 +16,115 @@
 
 package com.hp.application.automation.tools.octane.configuration;
 
+import com.google.inject.Inject;
 import com.hp.application.automation.tools.model.OctaneServerSettingsModel;
+import com.hp.application.automation.tools.octane.client.JenkinsMqmRestClientFactoryImpl;
 import com.hp.application.automation.tools.settings.OctaneServerSettingsBuilder;
+import com.hp.mqm.client.MqmRestClient;
+import com.hp.mqm.client.exception.LoginException;
+import com.hp.mqm.client.exception.RequestException;
+import com.hp.mqm.client.exception.SharedSpaceNotExistException;
 import hudson.Extension;
 import hudson.Plugin;
-import hudson.model.Hudson;
 import jenkins.model.Jenkins;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+/***
+ * Octane plugin configuration service -
+ * 1. helps to change Octane configuration
+ * 2. helps to get Octane configuration and model
+ * 3. helps to get RestClient based on some configuration
+ */
 @Extension
 public class ConfigurationService {
 
-	public static OctaneServerSettingsModel getModel() {
-		return getOctaneDescriptor().getModel();
-	}
+    private JenkinsMqmRestClientFactoryImpl clientFactory;
 
-	public static ServerConfiguration getServerConfiguration() {
-		return getOctaneDescriptor().getServerConfiguration();
-	}
+    private static Logger logger = LogManager.getLogger(ConfigurationService.class);
 
-	public static  void configurePlugin(OctaneServerSettingsModel newModel){
-		getOctaneDescriptor().setModel(newModel);
-	}
+    /**
+     * Get current {@see OctaneServerSettingsModel} model
+     *
+     * @return
+     */
+    public static OctaneServerSettingsModel getModel() {
+        return getOctaneDescriptor().getModel();
+    }
 
-	private static OctaneServerSettingsBuilder.OctaneDescriptorImpl getOctaneDescriptor(){
-		return  Hudson.getInstance().getDescriptorByType(OctaneServerSettingsBuilder.OctaneDescriptorImpl.class);
-	}
+    /**
+     * Get current Octane server configuration (that is based on model)
+     *
+     * @return
+     */
+    public static ServerConfiguration getServerConfiguration() {
+        return getOctaneDescriptor().getServerConfiguration();
+    }
 
-	public static String getPluginVersion(){
-		Plugin plugin = Jenkins.getInstance().getPlugin("hp-application-automation-tools-plugin");
-		return plugin.getWrapper().getVersion();
-	}
+    /**
+     * Change model (used by tests)
+     *
+     * @param newModel
+     */
+    public static void configurePlugin(OctaneServerSettingsModel newModel) {
+        getOctaneDescriptor().setModel(newModel);
+    }
+
+    private static OctaneServerSettingsBuilder.OctaneDescriptorImpl getOctaneDescriptor() {
+        return Jenkins.getInstance().getDescriptorByType(OctaneServerSettingsBuilder.OctaneDescriptorImpl.class);
+    }
+
+    /**
+     * Get plugin version
+     *
+     * @return
+     */
+    public static String getPluginVersion() {
+        Plugin plugin = Jenkins.getInstance().getPlugin("hp-application-automation-tools-plugin");
+        return plugin.getWrapper().getVersion();
+    }
+
+    /**
+     * Create restClient based on some server configuration
+     *
+     * @param serverConfiguration
+     * @return
+     */
+    public MqmRestClient createClient(ServerConfiguration serverConfiguration) {
+
+        if (!serverConfiguration.isValid()) {
+            logger.warn("MQM server configuration is not valid");
+            return null;
+        }
+
+        MqmRestClient client = clientFactory.obtain(
+                serverConfiguration.location,
+                serverConfiguration.sharedSpace,
+                serverConfiguration.username,
+                serverConfiguration.password);
+
+        try {
+            client.validateConfigurationWithoutLogin();
+            return client;
+        } catch (SharedSpaceNotExistException e) {
+            logger.warn("Invalid shared space");
+        } catch (LoginException e) {
+            logger.warn("Login failed : " + e.getMessage());
+        } catch (RequestException e) {
+            logger.warn("Problem with communication with MQM server : " + e.getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * Inject client factory
+     *
+     * @param clientFactory
+     */
+    @Inject
+    public void setMqmRestClientFactory(JenkinsMqmRestClientFactoryImpl clientFactory) {
+        this.clientFactory = clientFactory;
+    }
 
 }

--- a/src/main/java/com/hp/application/automation/tools/octane/events/TestListenerImpl.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/events/TestListenerImpl.java
@@ -1,16 +1,31 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
 package com.hp.application.automation.tools.octane.events;
 
 import com.google.inject.Inject;
 import com.hp.application.automation.tools.octane.tests.TestListener;
 import hudson.Extension;
-import hudson.model.Run;
-import hudson.model.TaskListener;
+import hudson.model.*;
 import hudson.model.listeners.RunListener;
 
 import javax.annotation.Nonnull;
 
 /**
- * Created by leviy on 27/03/2017.
+ * Listener on job complete event
  */
 @Extension
 public class TestListenerImpl extends RunListener<Run> {

--- a/src/main/java/com/hp/application/automation/tools/octane/executor/UFTTestDetectionResult.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/executor/UFTTestDetectionResult.java
@@ -17,33 +17,53 @@
 package com.hp.application.automation.tools.octane.executor;
 
 import com.hp.application.automation.tools.octane.actions.dto.AutomatedTest;
+import com.hp.application.automation.tools.octane.actions.dto.ScmResourceFile;
 
 import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 
-
-@XmlRootElement(name="detectionResult")
+/**
+ * This file represents result of UFT detection files (tests and data tables)
+ */
+@XmlRootElement(name = "detectionResult")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class UFTTestDetectionResult {
 
 
-    @XmlElementWrapper(name="newTests")
-    @XmlElement(name="test")
+    @XmlElementWrapper(name = "newTests")
+    @XmlElement(name = "test")
     private List<AutomatedTest> newTests = new ArrayList<>();
 
+    @XmlElementWrapper(name = "deletedTests")
+    @XmlElement(name = "test")
     private List<AutomatedTest> deletedTests = new ArrayList<>();
 
+    @XmlElementWrapper(name = "updatedTests")
+    @XmlElement(name = "test")
     private List<AutomatedTest> updatedTests = new ArrayList<>();
 
+    @XmlElementWrapper(name = "newDataTables")
+    @XmlElement(name = "dataTable")
+    private List<ScmResourceFile> newScmResourceFiles = new ArrayList<>();
+
+    @XmlElementWrapper(name = "deletedDataTables")
+    @XmlElement(name = "dataTable")
+    private List<ScmResourceFile> deletedScmResourceFiles = new ArrayList<>();
+
+    @XmlElementWrapper(name = "updatedDataTables")
+    @XmlElement(name = "dataTable")
+    private List<ScmResourceFile> updatedScmResourceFiles = new ArrayList<>();
+
+
     @XmlAttribute
-    private String scmResourceId;
+    private String scmRepositoryId;
 
     @XmlAttribute
     private String workspaceId;
 
     @XmlAttribute
-    private boolean initialDetection;
+    private boolean fullScan;
 
     public List<AutomatedTest> getNewTests() {
         return newTests;
@@ -57,12 +77,12 @@ public class UFTTestDetectionResult {
         return updatedTests;
     }
 
-    public String getScmResourceId() {
-        return scmResourceId;
+    public String getScmRepositoryId() {
+        return scmRepositoryId;
     }
 
-    public void setScmResourceId(String scmResourceId) {
-        this.scmResourceId = scmResourceId;
+    public void setScmRepositoryId(String scmRepositoryId) {
+        this.scmRepositoryId = scmRepositoryId;
     }
 
     public String getWorkspaceId() {
@@ -73,15 +93,29 @@ public class UFTTestDetectionResult {
         this.workspaceId = workspaceId;
     }
 
-    public boolean isInitialDetection() {
-        return initialDetection;
+    public boolean isFullScan() {
+        return fullScan;
     }
 
-    public void setInitialDetection(boolean initialDetection) {
-        this.initialDetection = initialDetection;
+    public void setFullScan(boolean fullScan) {
+        this.fullScan = fullScan;
     }
 
-    public boolean hasChanges(){
-        return !getNewTests().isEmpty() || !getUpdatedTests().isEmpty();
+    public boolean hasChanges() {
+        return !getNewTests().isEmpty() || !getUpdatedTests().isEmpty() || !getDeletedTests().isEmpty()
+                || !getNewScmResourceFiles().isEmpty() || !getDeletedScmResourceFiles().isEmpty() || !getUpdatedScmResourceFiles().isEmpty();
     }
+
+    public List<ScmResourceFile> getNewScmResourceFiles() {
+        return newScmResourceFiles;
+    }
+
+    public List<ScmResourceFile> getDeletedScmResourceFiles() {
+        return deletedScmResourceFiles;
+    }
+
+    public List<ScmResourceFile> getUpdatedScmResourceFiles() {
+        return updatedScmResourceFiles;
+    }
+
 }

--- a/src/main/java/com/hp/application/automation/tools/octane/executor/UftTestDiscoveryDispatcher.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/executor/UftTestDiscoveryDispatcher.java
@@ -17,24 +17,20 @@
 package com.hp.application.automation.tools.octane.executor;
 
 import com.google.inject.Inject;
+import com.hp.application.automation.tools.common.HttpStatus;
 import com.hp.application.automation.tools.octane.ResultQueue;
 import com.hp.application.automation.tools.octane.actions.UftTestType;
 import com.hp.application.automation.tools.octane.actions.dto.*;
-import com.hp.application.automation.tools.octane.client.JenkinsMqmRestClientFactory;
-import com.hp.application.automation.tools.octane.client.JenkinsMqmRestClientFactoryImpl;
 import com.hp.application.automation.tools.octane.configuration.ConfigurationService;
 import com.hp.application.automation.tools.octane.configuration.ServerConfiguration;
 import com.hp.application.automation.tools.octane.tests.AbstractSafeLoggingAsyncPeriodWork;
 import com.hp.mqm.client.MqmRestClient;
-import com.hp.mqm.client.exception.LoginException;
+import com.hp.mqm.client.QueryHelper;
 import com.hp.mqm.client.exception.RequestErrorException;
-import com.hp.mqm.client.exception.RequestException;
-import com.hp.mqm.client.exception.SharedSpaceNotExistException;
+import com.hp.mqm.client.model.Entity;
 import com.hp.mqm.client.model.ListItem;
 import com.hp.mqm.client.model.PagedList;
-import com.hp.mqm.client.model.Test;
 import hudson.Extension;
-import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -64,10 +60,13 @@ import java.util.*;
 public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 
     private static Logger logger = LogManager.getLogger(UftTestDiscoveryDispatcher.class);
-    private final static int RESPONSE_STATUS_CONFLICT = 409;
+    private final static String TESTS_COLLECTION_NAME = "automated_tests";
+    private final static String SCM_RESOURCE_FILES_COLLECTION_NAME = "scm_resource_files";
+
+    private final static int BULK_SIZE = 100;
 
     private UftTestDiscoveryQueue queue;
-    private JenkinsMqmRestClientFactory clientFactory;
+    private ConfigurationService configurationService;
 
     public UftTestDiscoveryDispatcher() {
         super("Uft Test Discovery Dispatcher");
@@ -81,82 +80,107 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
         }
 
         logger.warn("Queue size  " + queue.size());
-        //logger.info("... done, left to send " + events.size() + " events");
         ServerConfiguration serverConfiguration = ConfigurationService.getServerConfiguration();
-        MqmRestClient client = createClient(serverConfiguration);
+        MqmRestClient client = configurationService.createClient(serverConfiguration);
+
         if (client == null) {
+            logger.warn("There are pending discovered UFT tests, but MQM server configuration is not valid, results can't be submitted");
             return;
         }
 
-        ResultQueue.QueueItem item;
-        while ((item = queue.peekFirst()) != null) {
+        ResultQueue.QueueItem item = null;
+        try {
+            while ((item = queue.peekFirst()) != null) {
 
-            Job project = (Job) Jenkins.getInstance().getItemByFullName(item.getProjectName());
-            if (project == null) {
-                logger.warn("Project [" + item.getProjectName() + "] no longer exists, pending discovered tests can't be submitted");
+                Job project = (Job) Jenkins.getInstance().getItemByFullName(item.getProjectName());
+                if (project == null) {
+                    logger.warn("Project [" + item.getProjectName() + "] no longer exists, pending discovered tests can't be submitted");
+                    queue.remove();
+                    continue;
+                }
+
+                Run build = project.getBuildByNumber(item.getBuildNumber());
+                if (build == null) {
+                    logger.warn("Build [" + item.getProjectName() + "#" + item.getBuildNumber() + "] no longer exists, pending discovered tests can't be submitted");
+                    queue.remove();
+                    continue;
+                }
+
+                UFTTestDetectionResult result = UFTTestDetectionService.readDetectionResults(build);
+                if (result == null) {
+                    logger.warn("Build [" + item.getProjectName() + "#" + item.getBuildNumber() + "] no longer contains valid detection result file");
+                    queue.remove();
+                    continue;
+                }
+
+                logger.warn("Persistence [" + item.getProjectName() + "#" + item.getBuildNumber() + "]");
+                dispatchDetectionResults(item, client, result);
                 queue.remove();
-                continue;
             }
-
-            Run build = project.getBuildByNumber(item.getBuildNumber());
-            if (build == null) {
-                logger.warn("Build [" + item.getProjectName() + "#" + item.getBuildNumber() + "] no longer exists, pending discovered tests can't be submitted");
-                queue.remove();
-                continue;
+        } catch (Exception e) {
+            if (item != null) {
+                item.incrementFailCount();
+                int maxTrial = 5;
+                if (item.incrementFailCount() > maxTrial) {
+                    queue.remove();
+                    logger.warn("Failed to  persist discovery of [" + item.getProjectName() + "#" + item.getBuildNumber() + "]  after " + maxTrial + " trials");
+                }
             }
-
-            UFTTestDetectionResult result = UFTTestDetectionService.readDetectionResults(build);
-            if (result == null) {
-                logger.warn("Build [" + item.getProjectName() + "#" + item.getBuildNumber() + "] no longer contains valid detection result file");
-                queue.remove();
-                continue;
-            }
-
-            logger.warn("Persistence [" + item.getProjectName() + "#" + item.getBuildNumber() + "]");
-            dispatchDetectionResults(item, client, serverConfiguration, result);
-            if (result.isInitialDetection()) {
-                UFTTestDetectionService.createInitialDetectionFile(((AbstractBuild) build).getWorkspace());
-            }
-            queue.remove();
         }
     }
 
-    private void dispatchDetectionResults(ResultQueue.QueueItem item, MqmRestClient client, ServerConfiguration serverConfiguration, UFTTestDetectionResult result) throws UnsupportedEncodingException {
-        String serverURL = getServerURL(result.getWorkspaceId(), serverConfiguration.sharedSpace, serverConfiguration.location);
+    private void dispatchDetectionResults(ResultQueue.QueueItem item, MqmRestClient client, UFTTestDetectionResult result) throws UnsupportedEncodingException {
         //post new tests
         if (!result.getNewTests().isEmpty()) {
-            boolean posted = postTests(client, serverURL, result.getNewTests(), result.getWorkspaceId(), result.getScmResourceId());
+            boolean posted = postTests(client, result.getNewTests(), result.getWorkspaceId(), result.getScmRepositoryId());
             logger.warn("Persistence [" + item.getProjectName() + "#" + item.getBuildNumber() + "] : " + result.getNewTests().size() + "  new tests posted successfully = " + posted);
         }
 
-        //post updated
+        //post test updated
         if (!result.getUpdatedTests().isEmpty()) {
-            boolean updated = updateTests(client, result.getUpdatedTests(), result.getWorkspaceId());
+            boolean updated = updateTests(client, result.getUpdatedTests(), result.getWorkspaceId(), result.getScmRepositoryId());
             logger.warn("Persistence [" + item.getProjectName() + "#" + item.getBuildNumber() + "] : " + result.getUpdatedTests().size() + "  updated tests posted successfully = " + updated);
         }
+
+        //post test deleted
+        if (!result.getDeletedTests().isEmpty()) {
+            boolean updated = setTestsNotExecutable(client, result.getDeletedTests(), result.getWorkspaceId());
+            logger.warn("Persistence [" + item.getProjectName() + "#" + item.getBuildNumber() + "] : " + result.getDeletedTests().size() + "  deleted tests set as not executable successfully = " + updated);
+        }
+
+        //post scm resources
+        if (!result.getNewScmResourceFiles().isEmpty()) {
+            boolean posted = postScmResources(client, result.getNewScmResourceFiles(), result.getWorkspaceId(), result.getScmRepositoryId());
+            logger.warn("Persistence [" + item.getProjectName() + "#" + item.getBuildNumber() + "] : " + result.getNewScmResourceFiles().size() + "  new scmResources posted successfully = " + posted);
+        }
+
+        //delete scm resources
+        if (!result.getDeletedScmResourceFiles().isEmpty()) {
+            boolean posted = deleteScmResources(client, result.getDeletedScmResourceFiles(), result.getWorkspaceId(), result.getScmRepositoryId());
+            logger.warn("Persistence [" + item.getProjectName() + "#" + item.getBuildNumber() + "] : " + result.getDeletedScmResourceFiles().size() + "  scmResources deleted successfully = " + posted);
+        }
+
     }
 
-    private static boolean postTests(MqmRestClient client, String serverURL, List<AutomatedTest> tests, String workspaceId, String scmResourceId) throws UnsupportedEncodingException {
+    private static boolean postTests(MqmRestClient client, List<AutomatedTest> tests, String workspaceId, String scmRepositoryId) throws UnsupportedEncodingException {
 
         if (!tests.isEmpty()) {
             try {
-                completeTestProperties(client, Long.parseLong(workspaceId), tests, scmResourceId);
+                completeTestProperties(client, Long.parseLong(workspaceId), tests, scmRepositoryId);
             } catch (RequestErrorException e) {
                 logger.error("Failed to completeTestProperties : " + e.getMessage());
                 return false;
             }
 
-            int BULK_SIZE = 100;
             for (int i = 0; i < tests.size(); i += BULK_SIZE)
                 try {
                     AutomatedTests data = AutomatedTests.createWithTests(tests.subList(i, Math.min(i + BULK_SIZE, tests.size())));
                     String uftTestJson = convertToJsonString(data);
 
-                    client.postTest(uftTestJson, null, serverURL);
-                    //JSONObject testObject = (JSONObject) jsonObject.getJSONArray("data").get(0);
+                    client.postEntities(Long.parseLong(workspaceId), TESTS_COLLECTION_NAME, uftTestJson);
 
                 } catch (RequestErrorException e) {
-                    if (e.getStatusCode() != RESPONSE_STATUS_CONFLICT) {
+                    if (e.getStatusCode() != HttpStatus.CONFLICT.getCode()) {
                         logger.error("Failed to postTests to Octane : " + e.getMessage());
                         return false;
                     }
@@ -167,14 +191,38 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
         return true;
     }
 
-    private static String convertToJsonString(AutomatedTests data) {
-        JsonConfig config = getJsonConfig();
-        return JSONObject.fromObject(data, config).toString();
+    private static boolean postScmResources(MqmRestClient client, List<ScmResourceFile> resources, String workspaceId, String scmResourceId) throws UnsupportedEncodingException {
+
+        if (!resources.isEmpty()) {
+            try {
+                completeScmResourceProperties(resources, scmResourceId);
+            } catch (RequestErrorException e) {
+                logger.error("Failed to completeTestProperties : " + e.getMessage());
+                return false;
+            }
+
+            for (int i = 0; i < resources.size(); i += BULK_SIZE)
+                try {
+                    ScmResources data = ScmResources.createWithItems(resources.subList(i, Math.min(i + BULK_SIZE, resources.size())));
+                    String uftTestJson = convertToJsonString(data);
+
+                    client.postEntities(Long.parseLong(workspaceId), SCM_RESOURCE_FILES_COLLECTION_NAME, uftTestJson);
+
+                } catch (RequestErrorException e) {
+                    if (e.getStatusCode() != HttpStatus.CONFLICT.getCode()) {
+                        logger.error("Failed to post scm resource files to Octane : " + e.getMessage());
+                        return false;
+                    }
+
+                    //else :  the file with the same hash code , so do nothing
+                }
+        }
+        return true;
     }
 
-    private static String convertToJsonString(AutomatedTest test) {
+    private static String convertToJsonString(Object data) {
         JsonConfig config = getJsonConfig();
-        return JSONObject.fromObject(test, config).toString();
+        return JSONObject.fromObject(data, config).toString();
     }
 
     private static JsonConfig getJsonConfig() {
@@ -194,6 +242,25 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
                         break;
                     case "testTypes":
                         result = "test_type";
+                        break;
+                    default:
+                        break;
+                }
+                return result;
+            }
+        });
+
+        config.registerJsonPropertyNameProcessor(ScmResourceFile.class, new PropertyNameProcessor() {
+
+            @Override
+            public String processPropertyName(Class className, String fieldName) {
+                String result = fieldName;
+                switch (fieldName) {
+                    case "relativePath":
+                        result = "relative_path";
+                        break;
+                    case "scmRepository":
+                        result = "scm_repository";
                         break;
                     default:
                         break;
@@ -237,26 +304,22 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
         }
     }*/
 
-    private static boolean updateTests(MqmRestClient client, Collection<AutomatedTest> updateTests, String workspaceId) throws UnsupportedEncodingException {
+    private static boolean setTestsNotExecutable(MqmRestClient client, Collection<AutomatedTest> deletedTest, String workspaceId) throws UnsupportedEncodingException {
         long workspaceIdAsLong = Long.parseLong(workspaceId);
 
         try {
-            for (AutomatedTest test : updateTests) {
-                if (StringUtils.isEmpty(test.getDescription())) {
-                    continue;
-                }
-                Map<String, String> queryFields = new HashMap<>();
-                queryFields.put("name", test.getName());
-                queryFields.put("package", test.getPackage());
-                PagedList<Test> foundTests = client.getTests(workspaceIdAsLong, queryFields, Arrays.asList("id, description"));
+            for (AutomatedTest test : deletedTest) {
+                List<String> conditions = new ArrayList<>();
+                conditions.add(QueryHelper.condition("name", test.getName()));
+                conditions.add(QueryHelper.condition("package", test.getPackage()));
+                PagedList<Entity> foundTests = client.getEntities(workspaceIdAsLong, TESTS_COLLECTION_NAME, conditions, Arrays.asList("id"));
                 if (foundTests.getItems().size() == 1) {
-                    Test foundTest = foundTests.getItems().get(0);
+                    Entity foundTest = foundTests.getItems().get(0);
                     AutomatedTest testForUpdate = new AutomatedTest();
-                    testForUpdate.setSubtype(null);
-                    testForUpdate.setDescription(test.getDescription());
+                    testForUpdate.setExecutable(false);
                     testForUpdate.setId(foundTest.getId());
                     String json = convertToJsonString(testForUpdate);
-                    client.updateTest(Long.parseLong(workspaceId), foundTests.getItems().get(0).getId(), json);
+                    client.updateEntity(Long.parseLong(workspaceId), TESTS_COLLECTION_NAME, foundTests.getItems().get(0).getId(), json);
                 }
             }
             return true;
@@ -266,13 +329,80 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
         }
     }
 
-    private static void completeTestProperties(MqmRestClient client, long workspaceId, Collection<AutomatedTest> tests, String scmResourceId) {
+    private static boolean updateTests(MqmRestClient client, Collection<AutomatedTest> updateTests, String workspaceId, String scmRepositoryId) throws UnsupportedEncodingException {
+        long workspaceIdAsLong = Long.parseLong(workspaceId);
+
+        try {
+            List<AutomatedTest> createAsNewTests = new ArrayList<>();
+            for (AutomatedTest test : updateTests) {
+                if (StringUtils.isEmpty(test.getDescription())) {
+                    continue;
+                }
+
+                List<String> conditions = new ArrayList<>();
+                conditions.add(QueryHelper.condition("name", test.getName()));
+                conditions.add(QueryHelper.condition("package", test.getPackage()));
+                PagedList<Entity> foundTests = client.getEntities(workspaceIdAsLong, TESTS_COLLECTION_NAME, conditions, Arrays.asList("id"));
+                if (foundTests.getItems().size() == 1) {
+                    Entity foundTest = foundTests.getItems().get(0);
+                    AutomatedTest testForUpdate = new AutomatedTest();
+                    testForUpdate.setDescription(test.getDescription());
+                    testForUpdate.setExecutable(test.getExecutable());
+                    testForUpdate.setId(foundTest.getId());
+                    String json = convertToJsonString(testForUpdate);
+                    client.updateEntity(Long.parseLong(workspaceId), TESTS_COLLECTION_NAME, foundTests.getItems().get(0).getId(), json);
+                } else if (foundTests.getItems().size() == 0) {
+                    //test not exist in Octane, create it from scratch
+                    logger.error(String.format("Test %s\\%s should be updated but wasn't found on Octane, creating test from scratch ", test.getPackage(), test.getName()));
+                    createAsNewTests.add(test);
+
+                }
+            }
+
+
+            if (!createAsNewTests.isEmpty()) {
+                return postTests(client, createAsNewTests, workspaceId, scmRepositoryId);
+            } else {
+                return true;
+            }
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean deleteScmResources(MqmRestClient client, List<ScmResourceFile> deletedResourceFiles, String workspaceId, String scmRepositoryId) {
+
+        long workspaceIdAsLong = Long.parseLong(workspaceId);
+        Set<Long> deletedIds = new HashSet<>();
+        try {
+            for (ScmResourceFile scmResource : deletedResourceFiles) {
+                List<String> conditions = new ArrayList<>();
+                conditions.add(QueryHelper.condition("relative_path", scmResource.getRelativePath()));
+                conditions.add(QueryHelper.conditionRef("scm_repository", Long.valueOf(scmRepositoryId)));
+
+                PagedList<Entity> foundResources = client.getEntities(workspaceIdAsLong, SCM_RESOURCE_FILES_COLLECTION_NAME, conditions, Arrays.asList("id, name"));
+                if (foundResources.getItems().size() == 1) {
+                    Entity found = foundResources.getItems().get(0);
+                    deletedIds.add(found.getId());
+                }
+            }
+
+            client.deleteEntities(Long.parseLong(workspaceId), SCM_RESOURCE_FILES_COLLECTION_NAME, deletedIds);
+            return true;
+
+        } catch (Exception e) {
+            return false;
+        }
+
+    }
+
+    private static void completeTestProperties(MqmRestClient client, long workspaceId, Collection<AutomatedTest> tests, String scmRepositoryId) {
         ListNodeEntity uftTestingTool = getUftTestingTool(client, workspaceId);
         ListNodeEntity uftFramework = getUftFramework(client, workspaceId);
         ListNodeEntity guiTestType = hasTestsByType(tests, UftTestType.GUI) ? getGuiTestType(client, workspaceId) : null;
         ListNodeEntity apiTestType = hasTestsByType(tests, UftTestType.API) ? getApiTestType(client, workspaceId) : null;
 
-        BaseRefEntity scmRepository = StringUtils.isEmpty(scmResourceId) ? null : BaseRefEntity.create("scm_repository", Long.valueOf(scmResourceId));
+        BaseRefEntity scmRepository = StringUtils.isEmpty(scmRepositoryId) ? null : BaseRefEntity.create("scm_repository", Long.valueOf(scmRepositoryId));
         for (AutomatedTest test : tests) {
             test.setTestingToolType(uftTestingTool);
             test.setFramework(uftFramework);
@@ -283,6 +413,13 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
                 testType = apiTestType;
             }
             test.setTestTypes(ListNodeEntityCollection.create(testType));
+        }
+    }
+
+    private static void completeScmResourceProperties(List<ScmResourceFile> resources, String scmResourceId) {
+        BaseRefEntity scmRepository = StringUtils.isEmpty(scmResourceId) ? null : BaseRefEntity.create("scm_repository", Long.valueOf(scmResourceId));
+        for (ScmResourceFile resource : resources) {
+            resource.setScmRepository(scmRepository);
         }
     }
 
@@ -334,37 +471,6 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
         return null;
     }
 
-    private static String getServerURL(String workspaceId, String sharedspaceId, String location) {
-        return location + "/api/shared_spaces/" + sharedspaceId + "/workspaces/" + workspaceId;
-    }
-
-    private MqmRestClient createClient(ServerConfiguration serverConfiguration) {
-
-        if (!serverConfiguration.isValid()) {
-            logger.warn("There are pending discovered UFT tests, but MQM server configuration is not valid, results can't be submitted");
-            return null;
-        }
-
-        MqmRestClient client = clientFactory.obtain(
-                serverConfiguration.location,
-                serverConfiguration.sharedSpace,
-                serverConfiguration.username,
-                serverConfiguration.password);
-
-        try {
-            client.validateConfigurationWithoutLogin();
-            return client;
-        } catch (SharedSpaceNotExistException e) {
-            logger.warn("Invalid shared space");
-        } catch (LoginException e) {
-            logger.warn("Login failed : " + e.getMessage());
-        } catch (RequestException e) {
-            logger.warn("Problem with communication with MQM server : " + e.getMessage());
-        }
-
-        return null;
-    }
-
     @Override
     public long getRecurrencePeriod() {
         String value = System.getProperty("UftTestDiscoveryDispatcher.Period"); // let's us config the recurrence period. default is 60 seconds.
@@ -380,8 +486,8 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
     }
 
     @Inject
-    public void setMqmRestClientFactory(JenkinsMqmRestClientFactoryImpl clientFactory) {
-        this.clientFactory = clientFactory;
+    public void setConfigurationService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
     }
 
     private static boolean hasTestsByType(Collection<AutomatedTest> tests, UftTestType uftTestType) {

--- a/src/main/java/com/hp/application/automation/tools/octane/tests/build/MavenBuildExtension.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/tests/build/MavenBuildExtension.java
@@ -32,7 +32,7 @@ public class MavenBuildExtension extends BuildHandlerExtension {
 	@Override
 	public BuildDescriptor getBuildType(Run<?, ?> build) {
 		return new BuildDescriptor(
-				((AbstractBuild)build).getRootBuild().getProject().getName(),
+				BuildHandlerUtils.getJobCiId(build),
 				((AbstractBuild)build).getProject().getName(),
 				String.valueOf(build.getNumber()),
 				String.valueOf(build.getNumber()),
@@ -45,7 +45,7 @@ public class MavenBuildExtension extends BuildHandlerExtension {
 			// we don't push individual maven module results (although we create the file)
 			return null;
 		} else {
-			return ((AbstractBuild)build).getProject().getName();
+			return ((AbstractBuild)build).getProject().getFullName();
 		}
 	}
 }

--- a/src/main/resources/com/hp/application/automation/tools/octane/actions/UFTTestDetectionBuildAction/index.jelly
+++ b/src/main/resources/com/hp/application/automation/tools/octane/actions/UFTTestDetectionBuildAction/index.jelly
@@ -20,6 +20,11 @@
         color: #555753;
     }
 
+    .myTable caption{
+        font-weight: bold;
+        padding-bottom: 10px;
+    }
+
     .myTable td, .myTable th {
         border-left: 1px solid #cbcbcb;
         border-width: 0 0 0 1px;
@@ -58,9 +63,20 @@
                 <br/>
                 <br/>
             </j:if>
+            <j:if test="${it.hasNewScmResources}">
+                New data tables : ${it.results.newScmResourceFiles.size()}
+                <br/>
+                <br/>
+            </j:if>
+            <j:if test="${it.hasDeletedScmResources}">
+                Deleted data tables : ${it.results.deletedScmResourceFiles.size()}
+                <br/>
+                <br/>
+            </j:if>
          </p>
        <p>
        <table class = "myTable" frame="vsides above bottom" >
+        <caption>Tests</caption>
         <thead>
 
          <tr>
@@ -96,6 +112,36 @@
           </tbody>
        </table>
        </p>
+
+       <br/><br/>
+       <p>
+              <table class = "myTable" frame="vsides above bottom" >
+               <caption>Data tables</caption>
+               <thead>
+                <tr>
+                    <th>Path</th>
+                    <th>Status</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                  <j:forEach var="s" items="${it.results.newScmResourceFiles}">
+                      <tr>
+                          <td >${s.relativePath}</td>
+                          <td >new</td>
+                      </tr>
+                  </j:forEach>
+                  <j:forEach var="s" items="${it.results.deletedScmResourceFiles}">
+                        <tr>
+                            <td >${s.relativePath}</td>
+                            <td >deleted</td>
+                        </tr>
+                    </j:forEach>
+
+
+                 </tbody>
+              </table>
+              </p>
     </l:main-panel>
 
   </l:layout>

--- a/src/main/resources/com/hp/application/automation/tools/octane/actions/UFTTestDetectionPublisher/config.jelly
+++ b/src/main/resources/com/hp/application/automation/tools/octane/actions/UFTTestDetectionPublisher/config.jelly
@@ -16,7 +16,7 @@
           <f:select />
 </f:entry>
 
-<f:entry title="Octane scm repository id" field="scmResourceId"  description="Set scm repository id that will be assigned to discovered tests.">
+<f:entry title="Octane scm repository id" field="scmRepositoryId"  description="Set scm repository id that will be assigned to discovered tests.">
     <f:textbox />
   </f:entry>
 


### PR DESCRIPTION
* support discovery of data tables

* increment version of mqm-rest-client

* revert - last change

* small fixes

* fix running test from file system in mtbx file , while tests executed on slave

* small fixes

* support discovery of data tables

* support discovery of data tables

* tech: add license header

* Defect #317023: [ Jenkins plugin] Tests doesn't appear in Pipeline created from Maven project under Folder and always in status run

* improving JobCleaner to remove orphan discovery jobs

* adding fullScan parameter for discovery job

* 1.set deleted tests to be not executable
2.fix detection of deleted data tables
3.fix detection of test on linux (failed to replaceAll / by \\)

* add some java docs

* add some java docs

* codacy fixes

* tech : When deleting test from octane there is no option to updated it from UFT repository (the test doesn't exists)

* fix sonarLint issues

* refactor error handling of createMtbxFileInWs
