### PR TITLE
Change the format of test result executed by LabManagement 

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/sse/result/JUnitParser.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/result/JUnitParser.java
@@ -15,15 +15,18 @@ import com.hpe.application.automation.tools.sse.result.model.junit.Testsuite;
 import com.hpe.application.automation.tools.sse.result.model.junit.Testsuites;
 
 public class JUnitParser {
+
+    private String entityId;
     
     public Testsuites toModel(
             List<Map<String, String>> testInstanceRuns,
+            String entityId,
             String entityName,
             String runEntityId,
             String url,
             String domain,
             String project) {
-        
+        this.entityId = entityId;
         Map<String, Testsuite> testSetIdToTestsuite = getTestSets(testInstanceRuns);
         addTestcases(
                 testInstanceRuns,
@@ -94,33 +97,21 @@ public class JUnitParser {
         ret.setClassname(getTestSetName(entity, bvsName, runEntityId));
         ret.setName(getTestName(entity));
         ret.setTime(getTime(entity));
+        ret.setType(entity.get("test-subtype"));
         new TestcaseStatusUpdater().update(ret, entity, url, domain, project);
         
         return ret;
     }
-    
+
     private String getTestSetName(Map<String, String> entity, String bvsName, String runEntityId) {
-        
         String ret = String.format("%s.(Unnamed test set)", bvsName);
         String testSetName = entity.get("testset-name");
         if (!StringUtils.isNullOrEmpty(testSetName)) {
-            ret = String.format("%s (RunId:%s).%s", bvsName, runEntityId, testSetName);
+            ret = String.format("%s (id:%s).%s", bvsName, entityId, testSetName);
         }
-        
         return ret;
     }
-    
-    private String getTestInstanceRunId(Map<String, String> entity) {
-        
-        String ret = "No test instance run ID";
-        String runId = entity.get("run-id");
-        if (!StringUtils.isNullOrEmpty(runId)) {
-            ret = String.format("Test instance run ID: %s", runId);
-        }
-        
-        return ret;
-    }
-    
+
     private String getTestName(Map<String, String> entity) {
         
         String testName = entity.get("test-name");
@@ -128,7 +119,7 @@ public class JUnitParser {
             testName = "Unnamed test";
         }
         
-        return String.format("%s (%s)", testName, getTestInstanceRunId(entity));
+        return String.format("%s", testName);
     }
     
     private String getTime(Map<String, String> entity) {

--- a/src/main/java/com/hpe/application/automation/tools/sse/result/Publisher.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/result/Publisher.java
@@ -36,6 +36,7 @@ public abstract class Publisher extends Handler {
             ret =
                     new JUnitParser().toModel(
                             testInstanceRun,
+                            this.getEntityId(),
                             entityName,
                             _runId,
                             url,

--- a/src/test/java/com/hpe/application/automation/tools/sse/sdk/TestRunManager.java
+++ b/src/test/java/com/hpe/application/automation/tools/sse/sdk/TestRunManager.java
@@ -290,10 +290,8 @@ public class TestRunManager extends TestCase {
         Testcase testcase = testsuites.getTestsuite().get(0).getTestcase().get(0);
         ret =
                 (testcase.getStatus().equals(JUnitTestCaseStatus.PASS))
-                        && (testcase.getName().equals("vapi1 (Test instance run ID: 7)"))
-                        && (testcase.getClassname().equals(String.format(
-                                "%s1 (RunId:1005).testset1",
-                                runType))) && (testcase.getTime().equals("0.0"));
+                        && (testcase.getName().equals("vapi1"))
+                        && (testcase.getClassname().equals(String.format("%s1 (id:1041).testset1", runType))) && (testcase.getTime().equals("0.0"));
         
         return ret;
     }
@@ -304,7 +302,7 @@ public class TestRunManager extends TestCase {
         Testcase testcase = testsuites.getTestsuite().get(0).getTestcase().get(0);
         ret =
                 (testcase.getStatus().equals("error"))
-                        && (testcase.getName().equals("Unnamed test (No test instance run ID)"))
+                        && (testcase.getName().equals("Unnamed test"))
                         && (testcase.getClassname().equals("PC Test ID: 5, Run ID: 42, Test Set ID: 1.(Unnamed test set)"))
                         && (testcase.getTime().equals("0.0"));
         


### PR DESCRIPTION
Remove the run id from the test case's name.
Replace the run id with test set's entity id in the test case's class name.


