### PR TITLE
When UFT execution job fails before the test runs - we don't see it on Octane and suite run stays in Progress

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/octane/events/TestListenerImpl.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/events/TestListenerImpl.java
@@ -1,0 +1,40 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hpe.application.automation.tools.octane.events;
+
+import com.google.inject.Inject;
+import com.hpe.application.automation.tools.octane.tests.TestListener;
+import hudson.Extension;
+import hudson.model.*;
+import hudson.model.listeners.RunListener;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Listener on job complete event
+ */
+@Extension
+public class TestListenerImpl extends RunListener<Run> {
+
+	@Inject
+	private TestListener testListener;
+
+	@Override
+	public void onCompleted(Run r, @Nonnull TaskListener listener) {
+		testListener.processBuild(r, listener);
+	}
+}

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/TestListener.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/TestListener.java
@@ -24,7 +24,6 @@ import com.hpe.application.automation.tools.octane.tests.detection.UFTExtension;
 import com.hpe.application.automation.tools.octane.tests.xml.TestResultXmlWriter;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/TestListener.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/TestListener.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class TestListener {
 	private static Logger logger = LogManager.getLogger(TestListener.class);
 
-	static final String TEST_RESULT_FILE = "mqmTests.xml";
+	public static final String TEST_RESULT_FILE = "mqmTests.xml";
 	public static final String JENKINS_STORM_TEST_RUNNER_CLASS = "com.hpe.sr.plugins.jenkins.StormTestRunner";
 	public static final String JENKINS_PERFORMANCE_CENTER_TEST_RUNNER_CLASS = "com.hpe.application.automation.tools.run.PcBuilder";
 
@@ -121,11 +121,6 @@ public class TestListener {
 				logger.error("Error processing test results", xmlse);
 			}
 		}
-	}
-
-	private boolean isUFTRunner(AbstractBuild build) {
-		UFTExtension uftExtension = new UFTExtension();
-		return uftExtension.detect(build) != null;
 	}
 
 	@Inject

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
@@ -256,7 +256,7 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 		if (StringUtils.isEmpty(testName)) {
 			return testName;
 		}
-		return testName.trim().replaceAll("[-:\\ ,()/\\[\\]]", "_").replace('#', '_').replace('\\', '_');
+		return testName.trim().replaceAll("[-:\\ ,()/\\[\\]]", "_").replace('#', '_').replace('\\', '_').replace('.', '_');
 	}
 
 	private String jenkinsTestClassFormat(String className) {


### PR DESCRIPTION
user story #444126 : When UFT execution job fails before the test runs - we don't see it on Octane and suite run stays in Progress instead of "Failed" status

https://issues.jenkins-ci.org/browse/JENKINS-47228
