### PR TITLE
When UFT execution job fails before the test run…s - we don't see it on Octane and suite run stays in Progress instead of "Failed" status

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/octane/events/RunListenerImpl.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/events/RunListenerImpl.java
@@ -151,10 +151,16 @@ public final class RunListenerImpl extends RunListener<Run> {
 			.setResult(result)
 			.setDuration(r.getDuration());
 
-        if (r.getResult() == Result.FAILURE) {
-            boolean b = hasUftTests(r);
-            event.setTestResultExpected(b);
-        }
+		try {
+			if (r.getResult() == Result.FAILURE) {
+				Boolean hasTests = hasUftTests(r);
+				if (hasTests != null) {
+					event.setTestResultExpected(hasTests);
+				}
+			}
+		} catch (Exception e) {
+			//do nothing
+		}
 
 		if(r instanceof AbstractBuild){
 			event.setParameters(ParameterProcessors.getInstances(r))


### PR DESCRIPTION
user story #444126 : When UFT execution job fails before the test run…s - we don't see it on Octane and suite run stays in Progress instead of "Failed" status


