### PR TITLE
Collect coverage report of JaCoCo from Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,9 +393,9 @@
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
 			<version>1.4.13</version>
 		</dependency>
-		
+
 		<!-- NV jenkins plugins -->
-		
+
 		<dependency>
             <groupId>com.hpe.nv</groupId>
             <artifactId>hpe-nv-java-api</artifactId>

--- a/src/main/java/com/hpe/application/automation/tools/octane/AbstractResultQueueImpl.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/AbstractResultQueueImpl.java
@@ -92,6 +92,11 @@ public abstract class AbstractResultQueueImpl implements ResultQueue {
 		queue.add(new QueueItem(projectName, buildNumber));
 	}
 
+	@Override
+	public synchronized void add(String projectName, String type, int buildNumber) {
+		queue.add(new QueueItem(projectName, type, buildNumber));
+	}
+
 	public int size() {
 		return queue.size();
 	}
@@ -126,7 +131,7 @@ public abstract class AbstractResultQueueImpl implements ResultQueue {
 		}
 
 		private static QueueItem objectFromJson(JSONObject json) {
-			return json.containsKey("workspace") ?
+			QueueItem queueItem = json.containsKey("workspace") ?
 					new QueueItem(
 							json.getString("project"),
 							json.getInt("build"),
@@ -136,6 +141,10 @@ public abstract class AbstractResultQueueImpl implements ResultQueue {
 							json.getString("project"),
 							json.getInt("build"),
 							json.getInt("count"));
+			if (json.containsKey("type")) {
+				queueItem.setType(json.getString("type"));
+			}
+			return queueItem;
 		}
 
 		private static JSONObject jsonFromObject(QueueItem item) {
@@ -144,6 +153,7 @@ public abstract class AbstractResultQueueImpl implements ResultQueue {
 			json.put("build", item.buildNumber);
 			json.put("count", item.failCount);
 			json.put("workspace", item.workspace);
+			json.put("type", item.type);
 			return json;
 		}
 	}

--- a/src/main/java/com/hpe/application/automation/tools/octane/ResultQueue.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/ResultQueue.java
@@ -29,20 +29,33 @@ public interface ResultQueue {
 
     void add(String projectName, int buildNumber);
 
+    void add(String projectName, String type, int buildNumber);
+
     void add(String projectName, int buildNumber, String workspace);
 
     void clear();
 
     class QueueItem implements Serializable {
         private static final long serialVersionUID = 1;
-
+        public String type;
         String projectName;
         int buildNumber;
         String workspace;
         int failCount;
 
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+
         public QueueItem(String projectName, int buildNumber) {
             this(projectName, buildNumber, 0);
+        }
+
+        public QueueItem(String projectName, String type, int buildNumber) {
+            this(projectName, buildNumber, 0);
+            this.type = type;
         }
 
         public QueueItem(String projectName, int buildNumber, String workspace) {
@@ -61,6 +74,10 @@ public interface ResultQueue {
             this.buildNumber = buildNumber;
             this.failCount = failCount;
             this.workspace = workspace;
+        }
+
+        public String getType() {
+            return type;
         }
 
         public int incrementFailCount() {

--- a/src/main/java/com/hpe/application/automation/tools/octane/actions/CoveragePublisher.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/actions/CoveragePublisher.java
@@ -1,0 +1,166 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hpe.application.automation.tools.octane.actions;
+import com.hpe.application.automation.tools.octane.Messages;
+import com.hpe.application.automation.tools.octane.actions.coverage.CoveragePublisherAction;
+import com.hpe.application.automation.tools.octane.actions.coverage.CoverageService;
+import com.hpe.application.automation.tools.octane.tests.CoverageReportsDispatcher;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+/**
+ * Post-build action that collects the coverage reports from workspace
+ * the reports that matches a specified regular expression path, are copied to
+ * the build folder for future upload.
+ */
+public class CoveragePublisher extends Recorder {
+	private final String jacocoPathPattern;
+	private final String lcovPathPattern;
+	/**
+	 * this ctor is being called from configuration page.
+	 * the jacocoPathPattern is being injected from the web page text box
+	 * @param jacocoPathPattern regular expression path for coverage reports
+	 */
+	@DataBoundConstructor
+	public CoveragePublisher(String jacocoPathPattern, String lcovPathPattern) {
+		// Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
+		this.jacocoPathPattern = jacocoPathPattern == null || jacocoPathPattern.isEmpty() ? CoverageService.Jacoco.JACOCO_DEFAULT_PATH : jacocoPathPattern;
+		this.lcovPathPattern = lcovPathPattern == null || lcovPathPattern.isEmpty() ? CoverageService.Lcov.LCOV_DEFAULT_PATH : lcovPathPattern;
+	}
+
+	/**
+	 * this method used for serialization & deserialization of path
+	 * @return jacoco path
+	 */
+	public String getJacocoPathPattern() {
+		return jacocoPathPattern;
+	}
+
+	/**
+	 * this method used for serialization & deserialization of path
+	 * @return lcov path
+	 */
+	public String getLcovPathPattern() {
+		return lcovPathPattern;
+	}
+
+	/**
+	 * this is where we build the project. this method is being called when we run the build
+	 * @param build instance
+	 * @param launcher instance
+	 * @param listener for action attachment
+	 * @return status
+	 */
+	@Override
+	public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
+		boolean copyReportsToBuildFolderStatus = false;
+		ExtensionList<CoverageReportsDispatcher> extensionList = Jenkins.getInstance().getExtensionList(CoverageReportsDispatcher.class);
+		if (extensionList == null || extensionList.size() == 0) {
+			return false;
+		}
+		// copy coverage reports
+		CoveragePublisherAction action = new CoveragePublisherAction(build, listener);
+		build.addAction(action);
+		if (action.copyCoverageReportsToBuildFolder(jacocoPathPattern, CoverageService.Jacoco.JACOCO_DEFAULT_FILE_NAME)) {
+			extensionList.get(0).enqueueTask(build.getProject().getFullName(), build.getNumber(), CoverageService.Jacoco.JACOCO_TYPE);
+			copyReportsToBuildFolderStatus = true;
+		}
+		if (action.copyCoverageReportsToBuildFolder(lcovPathPattern, CoverageService.Lcov.LCOV_DEFAULT_FILE_NAME)) {
+			extensionList.get(0).enqueueTask(build.getProject().getFullName(), build.getNumber(), CoverageService.Lcov.LCOV_TYPE);
+			copyReportsToBuildFolderStatus |= true;
+		}
+		// add upload task to queue
+		return copyReportsToBuildFolderStatus;
+	}
+
+	/**
+	 * bound between descriptor to publisher
+	 * @return descriptor
+	 */
+	@Override
+	public DescriptorImpl getDescriptor() {
+		return (DescriptorImpl) super.getDescriptor();
+	}
+
+	/**
+	 * Returns BuildStepMonitor.NONE by default, as Builders normally don't depend on its previous result
+	 * @return monitor
+	 */
+	@Override
+	public BuildStepMonitor getRequiredMonitorService() {
+		return BuildStepMonitor.NONE;
+	}
+
+	/**
+	 * The Publisher object or Recorder is the base.
+	 * It needs a BuildStepDescriptor to provide certain information to Jenkins
+	 */
+	@Extension
+	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+		public DescriptorImpl() {
+			load();
+		}
+
+		/**
+		 * Indicates that this builder can be used with all kinds of project types
+		 * @param aClass that describe the job
+		 * @return always true, indicate that this post build action suitable for all jenkins jobs
+		 */
+		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+			return true; // so that it will also be available for maven & other projects
+		}
+
+		public String getDisplayName() {
+			return "HPE ALM Octane code coverage publisher";
+		}
+
+		public FormValidation doCheckJacocoPathPattern(@AncestorInPath AbstractProject project, @QueryParameter String value) throws IOException, ServletException {
+			if (value == null || value.isEmpty()) {
+				return FormValidation.warning(Messages.CoverageResultsActionEmptyConfigurationWarning(), CoverageService.Jacoco.JACOCO_DEFAULT_PATH);
+			} else if (project == null) {
+				return FormValidation.ok();
+			}
+			return FilePath.validateFileMask(project.getSomeWorkspace(), value);
+		}
+		public FormValidation doCheckLcovPathPattern(@AncestorInPath AbstractProject project, @QueryParameter String value) throws IOException, ServletException {
+			if (value == null || value.isEmpty()) {
+				return FormValidation.warning(Messages.CoverageResultsActionEmptyConfigurationWarning(), CoverageService.Lcov.LCOV_DEFAULT_PATH);
+			} else if (project == null) {
+				return FormValidation.ok();
+			}
+			return FilePath.validateFileMask(project.getSomeWorkspace(), value);
+		}
+	}
+}

--- a/src/main/java/com/hpe/application/automation/tools/octane/actions/coverage/CoveragePublisherAction.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/actions/coverage/CoveragePublisherAction.java
@@ -1,0 +1,97 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hpe.application.automation.tools.octane.actions.coverage;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+
+import java.io.File;
+import java.util.ArrayList;
+
+/**
+ * this action initiate a copy of all coverage reports from workspace to build folder.
+ * the files are calculated by a pattern that the user enters in job configuration page
+ */
+public class CoveragePublisherAction implements Action {
+    private final AbstractBuild build;
+
+    public CoveragePublisherAction(AbstractBuild build, BuildListener listener) {
+        this.build = build;
+        CoverageService.setListener(listener);
+    }
+
+    /**
+     * this method copy all reports from specified path pattern
+     * @return true if files have been copied, otherwise return false
+     */
+    public boolean copyCoverageReportsToBuildFolder(String filePattern, String defaultFileName) {
+        try {
+            CoverageService.log("start copying coverage report to build folder, using file patten of " + filePattern);
+            String[] files = CoverageService.getCoverageFiles(build.getWorkspace(), filePattern);
+            ArrayList<String> filteredFiles = filterFilesByFileExtension(files);
+            boolean found = filteredFiles.size() > 0;
+            int index = 0;
+
+            for (String fileName : filteredFiles) {
+                File resultFile = new File(build.getWorkspace().child(fileName).toURI());
+                File targetReportFile = new File(build.getRootDir(), CoverageService.getCoverageReportFileName(index++, defaultFileName));
+                CoverageService.copyCoverageFile(resultFile, targetReportFile, build.getWorkspace());
+            }
+
+            if (!found) {
+                // most likely a configuration error in the job - e.g. false pattern to match the cucumber result files
+                CoverageService.log("No coverage file that matched the specified pattern was found in workspace");
+            }
+            return found;
+
+        } catch (Exception e) {
+            CoverageService.log("Copying coverage files to build folder failed because of " + e.toString());
+            return false;
+        }
+    }
+
+    /**
+     * pre validation of coverage files by file extension.
+     * @param files to validate
+     * @return filtered list of files
+     */
+    private ArrayList<String> filterFilesByFileExtension(String[] files) {
+        ArrayList<String> filteredList = new ArrayList<>();
+        for (String fileFullPath : files) {
+            if (fileFullPath.endsWith(CoverageService.Lcov.LCOV_FILE_EXTENSION) || fileFullPath.endsWith(CoverageService.Jacoco.JACOCO_FILE_EXTENSION)) {
+                filteredList.add(fileFullPath);
+            }
+        }
+        return filteredList;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+}

--- a/src/main/java/com/hpe/application/automation/tools/octane/actions/coverage/CoverageService.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/actions/coverage/CoverageService.java
@@ -1,0 +1,131 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hpe.application.automation.tools.octane.actions.coverage;
+
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.BuildListener;
+import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
+import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.types.FileSet;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * Helper Service for coverage publisher
+ */
+public class CoverageService {
+    private static final String COVERAGE_REPORT_FILE_NAME_PREFIX = "coverage_report";
+    private static BuildListener listener;
+
+    public static class Jacoco {
+        public static final String JACOCO_TYPE = "JACOCOXML";
+        public static final String JACOCO_FILE_EXTENSION = ".xml";
+        public static final String JACOCO_DEFAULT_FILE_NAME = "jacoco" + JACOCO_FILE_EXTENSION;
+        public static final String JACOCO_DEFAULT_PATH = "**/target/site/*/" + JACOCO_DEFAULT_FILE_NAME;
+
+    }
+    public static class Lcov {
+        public static final String LCOV_TYPE = "LCOV";
+        public static final String LCOV_FILE_EXTENSION = ".info";
+        public static final String LCOV_DEFAULT_FILE_NAME = "lcov" + LCOV_FILE_EXTENSION;
+        public static final String LCOV_DEFAULT_PATH = "**/coverage/" + LCOV_DEFAULT_FILE_NAME;
+
+    }
+
+    public static String getCoverageReportFileName(int index, String fileSuffix) {
+        return COVERAGE_REPORT_FILE_NAME_PREFIX + index + "-" + fileSuffix;
+    }
+
+    public static String[] getCoverageFiles(final FilePath workspace, String glob) throws IOException, InterruptedException {
+        log(String.format("Looking for files that match the pattern %s in root directory %s", glob, workspace.getName()));
+        return workspace.act(new ResultFilesCallable(glob));
+    }
+
+    public static void copyCoverageFile(File resultFile, File targetReportFile, final FilePath workspace) throws IOException, InterruptedException {
+        log(String.format("Copying %s to %s", resultFile.getPath(), targetReportFile));
+
+        byte[] content = workspace.act(new FileContentCallable(resultFile));
+
+        if (validateContent(content)) {
+            log("Got coverage file content");
+
+            try (FileOutputStream os = new FileOutputStream(targetReportFile)) {
+                os.write(content);
+            }
+            log(String.format("coverage file copied successfully to %s", targetReportFile.getPath()));
+        } else {
+            log("coverage file content corrupted, failed to copy the file to target destination");
+        }
+    }
+
+    /**
+     * most of the validations will be done in octane side
+     * this is a place holder to do more validations if needed
+     * @param content of the file
+     * @return status
+     */
+    private static boolean validateContent(byte[] content) {
+        return content.length > 0;
+    }
+
+    public static void log(final String message) {
+        if(listener != null) {
+            listener.getLogger().println(message);
+        }
+    }
+
+    public static void setListener(BuildListener l) {
+        listener = l;
+    }
+
+    /**
+     * this class searched for files that match specific pattern
+     */
+    private static final class ResultFilesCallable extends MasterToSlaveFileCallable<String[]> {
+        private final String glob;
+
+        private ResultFilesCallable(String glob) {
+            this.glob = glob;
+        }
+
+        @Override
+        public String[] invoke(File rootDir, VirtualChannel channel) throws IOException {
+            FileSet fs = Util.createFileSet(rootDir, glob);
+            DirectoryScanner ds = fs.getDirectoryScanner();
+            return ds.getIncludedFiles();
+        }
+    }
+
+    private static final class FileContentCallable extends MasterToSlaveFileCallable<byte[]> {
+        private final File file;
+
+        private FileContentCallable(File file) {
+            this.file = file;
+        }
+
+        @Override
+        public byte[] invoke(File rootDir, VirtualChannel channel) throws IOException {
+            return Files.readAllBytes(file.toPath());
+        }
+    }
+
+}

--- a/src/main/java/com/hpe/application/automation/tools/octane/executor/CoverageReportsQueue.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/executor/CoverageReportsQueue.java
@@ -1,0 +1,41 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hpe.application.automation.tools.octane.executor;
+
+import com.hpe.application.automation.tools.octane.AbstractResultQueueImpl;
+import jenkins.model.Jenkins;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Queue for jenkins coverage reports before dispatching
+ */
+public class CoverageReportsQueue extends AbstractResultQueueImpl {
+
+    public CoverageReportsQueue(int maxRetries) throws IOException {
+        super(maxRetries);
+        Jenkins jenkinsContainer = Jenkins.getInstance();
+        if (jenkinsContainer != null) {
+            File queueFile = new File(jenkinsContainer.getRootDir(), "coverage-reports-queue.dat");
+            init(queueFile);
+        } else {
+            throw new IllegalStateException("Jenkins container not initialized properly");
+        }
+    }
+
+}

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/CoverageReportsDispatcher.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/CoverageReportsDispatcher.java
@@ -1,0 +1,229 @@
+/*
+ *     Copyright 2017 Hewlett-Packard Development Company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.hpe.application.automation.tools.octane.tests;
+
+import com.google.common.primitives.Longs;
+import com.google.inject.Inject;
+import com.hp.mqm.client.MqmRestClient;
+import com.hp.mqm.client.exception.RequestErrorException;
+import com.hpe.application.automation.tools.octane.ResultQueue;
+import com.hpe.application.automation.tools.octane.actions.coverage.CoverageService;
+import com.hpe.application.automation.tools.octane.client.JenkinsInsightEventPublisher;
+import com.hpe.application.automation.tools.octane.client.JenkinsMqmRestClientFactory;
+import com.hpe.application.automation.tools.octane.client.JenkinsMqmRestClientFactoryImpl;
+import com.hpe.application.automation.tools.octane.client.RetryModel;
+import com.hpe.application.automation.tools.octane.configuration.ConfigurationService;
+import com.hpe.application.automation.tools.octane.configuration.ServerConfiguration;
+import com.hpe.application.automation.tools.octane.executor.CoverageReportsQueue;
+import com.hpe.application.automation.tools.octane.tests.build.BuildHandlerUtils;
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.TimeUnit2;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * this class manages a queue of coverage report upload tasks
+ */
+@Extension
+public class CoverageReportsDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
+	private static final Logger logger = LogManager.getLogger(CoverageReportsDispatcher.class);
+
+	private static final int MAX_RETRIES = 6;
+
+	private static final double BASE = 2;
+	private static final double EXPONENT = 0;
+	@Inject
+	private RetryModel retryModel;
+	private JenkinsMqmRestClientFactory clientFactory;
+	private final ResultQueue reportsQueue;
+	@Inject
+	public CoverageReportsDispatcher() throws IOException {
+		super("Octane coverage reports dispatcher");
+		reportsQueue = new CoverageReportsQueue(MAX_RETRIES);
+	}
+
+	private long[] getQuietPeriodsInMinutes(double retries) {
+		double exponent = EXPONENT;
+		List<Long> quietPeriods = new ArrayList<>();
+		while (exponent <= retries) {
+			quietPeriods.add(TimeUnit2.MINUTES.toMillis((long) Math.pow(BASE, exponent)));
+			exponent++;
+		}
+		return Longs.toArray(quietPeriods);
+	}
+
+	@Override
+	protected void doExecute(TaskListener listener) {
+		if (reportsQueue.peekFirst() == null) {
+			return;
+		}
+
+		MqmRestClient mqmRestClient = initMqmRestClient();
+		if (mqmRestClient == null) {
+			logger.warn("There are pending coverage reports, but MQM server location is not specified, reports can't be submitted");
+			reportsQueue.remove();
+			return;
+		}
+
+		ResultQueue.QueueItem item;
+
+		while ((item = reportsQueue.peekFirst()) != null) {
+
+			if (retryModel.isQuietPeriod()) {
+				logger.debug("There are pending coverage reports, but we are in quiet period");
+				return;
+			}
+
+			Run build = getBuildFromQueueItem(item);
+			if (build == null) {
+				logger.warn("Build and/or Project [" + item.getProjectName() + "#" + item.getBuildNumber() + "] no longer exists, pending coverage reports can't be submitted");
+				reportsQueue.remove();
+				continue;
+			}
+			if (item.getType().equals(CoverageService.Jacoco.JACOCO_TYPE)) {
+				transferCoverageReports(build, mqmRestClient, item, CoverageService.Jacoco.JACOCO_DEFAULT_FILE_NAME);
+			} else if (item.getType().equals(CoverageService.Lcov.LCOV_TYPE)) {
+				transferCoverageReports(build, mqmRestClient, item, CoverageService.Lcov.LCOV_DEFAULT_FILE_NAME);
+			}
+		}
+	}
+
+	private void transferCoverageReports(Run build, MqmRestClient mqmRestClient, ResultQueue.QueueItem item, String coverageReportFileSuffix) {
+		long index = 0;
+		File coverageFile = getCoverageFile(build, index, coverageReportFileSuffix);
+		try {
+			// iterate all coverage reports in build folder
+			while (coverageFile.exists()) {
+				// send each report as IS to octane using rest client
+				boolean status = mqmRestClient.postCoverageReports(
+						ConfigurationService.getModel().getIdentity(),
+						BuildHandlerUtils.getJobCiId(build),
+						String.valueOf(build.getNumber()),
+						new FileInputStream(coverageFile),
+						coverageFile.length(), item.getType());
+				if (status) {
+					logger.info("Successfully sent coverage report " + coverageFile.getName() + " for job " + item.getProjectName() + " with build #" + item.getBuildNumber());
+				} else {
+					logger.error("failed to send coverage report " + coverageFile.getName() + " for job " + item.getProjectName() + " with build #" + item.getBuildNumber());
+					reAttemptTask(item.getProjectName(), item.getBuildNumber(), item.getType());
+					return;
+				}
+				// get next file
+				index++;
+				coverageFile = getCoverageFile(build, index, coverageReportFileSuffix);
+			}
+			reportsQueue.remove();
+		} catch (RequestErrorException ree) {
+			logger.error("failed to send coverage reports (of type " + item.getType() + ") for job " + item.getProjectName() + " #" + item.getBuildNumber(), ree);
+			reAttemptTask(item.getProjectName(), item.getBuildNumber(), item.getType());
+		} catch (Exception e) {
+			logger.error("fatally failed to send coverage reports (of type " + item.getType() + ") for build " + item.getProjectName() + " #" + item.getBuildNumber() + ", will not retry this one", e);
+			retryModel.success();
+			reportsQueue.remove();
+		}
+	}
+
+	private File getCoverageFile(Run build, long index, String coverageReportFileSuffix) {
+		String coverageReportFilePath = build.getRootDir() + File.separator + CoverageService.getCoverageReportFileName((int) index, coverageReportFileSuffix);
+		return new File(coverageReportFilePath);
+	}
+
+	private void reAttemptTask(String projectName, int buildNumber, String itemReportType) {
+		if (!reportsQueue.failed()) { // add task to queue and return true if max attempts not reached, else return false
+			logger.warn("maximum number of attempts reached (" + MAX_RETRIES + "), " +
+					"operation will not be re-attempted for build "+ projectName + " #" + buildNumber + " of type " + itemReportType);
+			retryModel.success();
+		} else {
+			logger.info("There are pending logs, but we are in quiet period");
+			retryModel.failure();
+		}
+	}
+
+	private MqmRestClient initMqmRestClient() {
+		MqmRestClient result = null;
+		ServerConfiguration configuration = ConfigurationService.getServerConfiguration();
+		if (configuration.isValid()) {
+			result = clientFactory.obtain(
+					configuration.location,
+					configuration.sharedSpace,
+					configuration.username,
+					configuration.password);
+		}
+		return result;
+	}
+
+	private Run getBuildFromQueueItem(ResultQueue.QueueItem item) {
+		Run result = null;
+		Job project = (Job) Jenkins.getInstance().getItemByFullName(item.getProjectName());
+		if (project != null) {
+			result = project.getBuildByNumber(item.getBuildNumber());
+		}
+		return result;
+	}
+
+	@Override
+	public long getRecurrencePeriod() {
+		String value = System.getProperty("Octane.LogDispatcher.Period"); // let's us config the recurrence period. default is 10 seconds.
+		if (!StringUtils.isEmpty(value)) {
+			return Long.valueOf(value);
+		}
+		return TimeUnit2.SECONDS.toMillis(10);
+	}
+
+	public void enqueueTask(String projectName, int buildNumber, String fileType) {
+		reportsQueue.add(projectName, fileType, buildNumber);
+	}
+
+	@Inject
+	public void setEventPublisher(JenkinsInsightEventPublisher eventPublisher) {
+		this.retryModel = new RetryModel(eventPublisher, getQuietPeriodsInMinutes(MAX_RETRIES));
+	}
+
+	@Inject
+	public void setMqmRestClientFactory(JenkinsMqmRestClientFactoryImpl clientFactory) {
+		this.clientFactory = clientFactory;
+	}
+
+	private static final class NamedThreadFactory implements ThreadFactory {
+
+		private AtomicInteger threadNumber = new AtomicInteger(1);
+		private final String namePrefix;
+
+		private NamedThreadFactory(String namePrefix) {
+			this.namePrefix = namePrefix;
+		}
+
+		public Thread newThread(Runnable runnable) {
+			Thread result = new Thread(runnable, this.namePrefix + " thread-" + threadNumber.getAndIncrement());
+			result.setDaemon(true);
+			return result;
+		}
+	}
+}

--- a/src/main/resources/com/hpe/application/automation/tools/octane/Messages.properties
+++ b/src/main/resources/com/hpe/application/automation/tools/octane/Messages.properties
@@ -42,3 +42,6 @@ CucumberResultsActionCollecting=Collecting Cucumber results to send to Octane.
 CucumberResultsActionNotFound=Cucumber result XMLs for Octane were not found. Configuration error?
 CucumberResultsActionError=Error while collecting Cucumber result XMLs: %s
 CucumberResultsActionEmptyConfigurationWarning=Leaving this field empty will result in searching for %s
+
+
+CoverageResultsActionEmptyConfigurationWarning=Leaving this field empty will result in searching for %s

--- a/src/main/resources/com/hpe/application/automation/tools/octane/actions/CoveragePublisher/config.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/octane/actions/CoveragePublisher/config.jelly
@@ -1,0 +1,24 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:s="/lib/samples">
+  <!--
+    This jelly script is used for per-project configuration.
+
+    See global.jelly for a general discussion about jelly script.
+  -->
+
+  <!--
+    Creates a text field that shows the value of the "name" property.
+    When submitted, it will be passed to the corresponding constructor parameter.
+  -->
+
+    <f:entry title="Jacoco coverage report XMLs" field="jacocoPathPattern"
+             description="${%descriptionJacoco('http://ant.apache.org/manual/Types/fileset.html')}">
+        <f:textbox />
+    </f:entry>
+
+        <f:entry title="Lcov coverage report info files" field="lcovPathPattern"
+                 description="${%descriptionLcov('http://ant.apache.org/manual/Types/fileset.html')}">
+            <f:textbox />
+        </f:entry>
+
+</j:jelly>

--- a/src/main/resources/com/hpe/application/automation/tools/octane/actions/CoveragePublisher/config.properties
+++ b/src/main/resources/com/hpe/application/automation/tools/octane/actions/CoveragePublisher/config.properties
@@ -1,0 +1,25 @@
+#
+#     Copyright 2017 Hewlett-Packard Development Company, L.P.
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+#
+
+descriptionJacoco=\
+<a href="{0}">Fileset \u2018includes\u2019</a> \
+setting that specifies the location of the Jacoco files from which to pull coverage data. \
+Basedir of the fileset is <a href="ws/">the workspace root</a>.
+
+descriptionLcov=\
+<a href="{0}">Fileset \u2018includes\u2019</a> \
+setting that specifies the location of the Jacoco files from which to pull coverage data. \
+Basedir of the fileset is <a href="ws/">the workspace root</a>.

--- a/src/test/java/com/hpe/application/automation/tools/octane/tests/TestQueue.java
+++ b/src/test/java/com/hpe/application/automation/tools/octane/tests/TestQueue.java
@@ -61,6 +61,17 @@ public class TestQueue implements ResultQueue {
 		queue.add(new QueueItem(projectName, buildNumber));
 	}
 
+	/**
+	 * add task to queue, type is not relevant to to test queue
+	 * @param projectName
+	 * @param type
+	 * @param buildNumber
+	 */
+	@Override
+	public void add(String projectName, String type, int buildNumber) {
+		queue.add(new QueueItem(projectName, buildNumber));
+	}
+
 	@Override
 	public void add(String projectName, int buildNumber, String workspace) {
 		queue.add(new QueueItem(projectName, buildNumber, workspace));


### PR DESCRIPTION
u.s #450005 - [tech] Collect coverage report of JaCoCo from Jenkins and send them to Octane (+including remote such as slaves) + queue in Jenkins.

[JENKINS-47956](https://issues.jenkins-ci.org/browse/JENKINS-47956)