### PR TITLE
defect #718030: fixing SRF/SRL/PC tests type detection (JENKINS-53674)

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/TestListener.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/TestListener.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
  *  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
  *  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
@@ -17,7 +16,6 @@
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
- *
  */
 
 package com.microfocus.application.automation.tools.octane.tests;
@@ -47,9 +45,9 @@ import java.util.List;
 public class TestListener {
 	private static Logger logger = LogManager.getLogger(TestListener.class);
 
-	private static final String JENKINS_STORMRUNNER_LOAD_TEST_RUNNER_CLASS = "com.hpe.sr.plugins.jenkins.StormTestRunner";
-	private static final String JENKINS_STORMRUNNER_FUNCTIONAL_TEST_RUNNER_CLASS = "com.hpe.application.automation.tools.srf.run.RunFromSrfBuilder";
-	private static final String JENKINS_PERFORMANCE_CENTER_TEST_RUNNER_CLASS = "com.hpe.application.automation.tools.run.PcBuilder";
+	private static final String STORMRUNNER_LOAD_TEST_RUNNER_CLASS = "StormTestRunner";
+	private static final String STORMRUNNER_FUNCTIONAL_TEST_RUNNER_CLASS = "RunFromSrfBuilder";
+	private static final String PERFORMANCE_CENTER_TEST_RUNNER_CLASS = "PcBuilder";
 	public static final String TEST_RESULT_FILE = "mqmTests.xml";
 
 	private ResultQueue queue;
@@ -64,19 +62,19 @@ public class TestListener {
 		List<Builder> builders = JobProcessorFactory.getFlowProcessor(run.getParent()).tryGetBuilders();
 		if (builders != null) {
 			for (Builder builder : builders) {
-				if (builder.getClass().getName().equals(JENKINS_STORMRUNNER_LOAD_TEST_RUNNER_CLASS)) {
+				if (STORMRUNNER_LOAD_TEST_RUNNER_CLASS.equals(builder.getClass().getSimpleName())) {
 					hpRunnerType = HPRunnerType.StormRunnerLoad;
 					break;
 				}
-				if (builder.getClass().getName().equals(JENKINS_STORMRUNNER_FUNCTIONAL_TEST_RUNNER_CLASS)) {
+				if (STORMRUNNER_FUNCTIONAL_TEST_RUNNER_CLASS.equals(builder.getClass().getSimpleName())) {
 					hpRunnerType = HPRunnerType.StormRunnerFunctional;
 					break;
 				}
-				if (builder.getClass().getName().equals(UFTExtension.RUN_FROM_FILE_BUILDER) || builder.getClass().getName().equals(UFTExtension.RUN_FROM_ALM_BUILDER)) {
+				if (UFTExtension.RUN_FROM_FILE_BUILDER.equals(builder.getClass().getSimpleName()) || UFTExtension.RUN_FROM_ALM_BUILDER.equals(builder.getClass().getSimpleName())) {
 					hpRunnerType = HPRunnerType.UFT;
 					break;
 				}
-				if (builder.getClass().getName().equals(JENKINS_PERFORMANCE_CENTER_TEST_RUNNER_CLASS)) {
+				if (PERFORMANCE_CENTER_TEST_RUNNER_CLASS.equals(builder.getClass().getSimpleName())) {
 					hpRunnerType = HPRunnerType.PerformanceCenter;
 					break;
 				}

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/detection/UFTExtension.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/detection/UFTExtension.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
  *  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
  *  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
@@ -17,7 +16,6 @@
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
- *
  */
 
 package com.microfocus.application.automation.tools.octane.tests.detection;
@@ -31,21 +29,20 @@ import hudson.tasks.Builder;
 @Extension
 public class UFTExtension extends ResultFieldsDetectionExtension {
 
-    public static final String UFT = "UFT";
+	public static final String UFT = "UFT";
 
-    public static final String RUN_FROM_FILE_BUILDER = "com.microfocus.application.automation.tools.run.RunFromFileBuilder";
-    public static final String RUN_FROM_ALM_BUILDER = "com.microfocus.application.automation.tools.run.RunFromAlmBuilder";
+	public static final String RUN_FROM_FILE_BUILDER = "RunFromFileBuilder";
+	public static final String RUN_FROM_ALM_BUILDER = "RunFromAlmBuilder";
 
-    @Override
-    public ResultFields detect(final Run build) {
-
-        if (build.getParent() instanceof FreeStyleProject) {
-            for (Builder builder : ((FreeStyleProject) build.getParent()).getBuilders()) {
-                if (builder.getClass().getName().equals(RUN_FROM_FILE_BUILDER) || builder.getClass().getName().equals(RUN_FROM_ALM_BUILDER)) {
-                        return new ResultFields(UFT, UFT, null);
-                }
-            }
-        }
-        return null;
-    }
+	@Override
+	public ResultFields detect(final Run build) {
+		if (build.getParent() instanceof FreeStyleProject) {
+			for (Builder builder : ((FreeStyleProject) build.getParent()).getBuilders()) {
+				if (RUN_FROM_FILE_BUILDER.equals(builder.getClass().getSimpleName()) || RUN_FROM_ALM_BUILDER.equals(builder.getClass().getSimpleName())) {
+					return new ResultFields(UFT, UFT, null);
+				}
+			}
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
domestic test types detection should be done by using simple class name and not fully qualified, which is (more) easily brakable
[JENKINS-53674](https://issues.jenkins-ci.org/browse/JENKINS-53674)