### PR TITLE
issue-53873: handling internally any failure related to our own events processing

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/ItemListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/ItemListenerOctaneImpl.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
  *  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
  *  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
@@ -17,7 +16,6 @@
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
- *
  */
 
 package com.microfocus.application.automation.tools.octane.events;
@@ -30,6 +28,8 @@ import com.microfocus.application.automation.tools.octane.model.processors.proje
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.listeners.ItemListener;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
 /**
@@ -41,18 +41,22 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
 @Extension
 public class ItemListenerOctaneImpl extends ItemListener {
+	private static final Logger logger = LogManager.getLogger(ItemListenerOctaneImpl.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	@Override
 	public void onDeleted(Item item) {
-		CIEvent event;
+		try {
+			CIEvent event;
+			if (item.getParent() != null && item.getParent().getClass().getName().equalsIgnoreCase(JobProcessorFactory.WORKFLOW_MULTI_BRANCH_JOB_NAME)) {
+				event = dtoFactory.newDTO(CIEvent.class)
+						.setEventType(CIEventType.DELETED)
+						.setProject(JobProcessorFactory.getFlowProcessor((WorkflowJob) item).getTranslateJobName());
 
-		if (item.getParent() != null && item.getParent().getClass().getName().equalsIgnoreCase(JobProcessorFactory.WORKFLOW_MULTI_BRANCH_JOB_NAME)) {
-			event = dtoFactory.newDTO(CIEvent.class)
-					.setEventType(CIEventType.DELETED)
-					.setProject(JobProcessorFactory.getFlowProcessor((WorkflowJob) item).getTranslateJobName());
-
-			OctaneSDK.getInstance().getEventsService().publishEvent(event);
+				OctaneSDK.getInstance().getEventsService().publishEvent(event);
+			}
+		} catch (Throwable throwable) {
+			logger.error("failed to build and/or dispatch DELETED event for " + item, throwable);
 		}
 	}
 }

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/SCMListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/SCMListenerOctaneImpl.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Certain versions of software and/or documents (“Material”) accessible here may contain branding from
  *  Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
  *  the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
@@ -17,7 +16,6 @@
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
- *
  */
 
 package com.microfocus.application.automation.tools.octane.events;
@@ -58,12 +56,6 @@ public class SCMListenerOctaneImpl extends SCMListener {
 	private static final Logger logger = LogManager.getLogger(SCMListenerOctaneImpl.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
-
-	@Override
-	public void onCheckout(Run<?, ?> build, SCM scm, FilePath workspace, TaskListener listener, File changelogFile, SCMRevisionState pollingBaseline) throws Exception {
-		super.onCheckout(build, scm, workspace, listener, changelogFile, pollingBaseline);
-	}
-
 	@Override
 	public void onChangeLogParsed(Run<?, ?> run, SCM scm, TaskListener listener, ChangeLogSet<?> changelog) throws Exception {
 		super.onChangeLogParsed(run, scm, listener, changelog);
@@ -81,10 +73,14 @@ public class SCMListenerOctaneImpl extends SCMListener {
 			return;
 		}
 
-		SCMData scmData = extractSCMData(run, scm, scmProcessor);
-		if (scmData != null) {
-			CIEvent event = createSCMEvent(run, scmData);
-			OctaneSDK.getInstance().getEventsService().publishEvent(event);
+		try {
+			SCMData scmData = extractSCMData(run, scm, scmProcessor);
+			if (scmData != null) {
+				CIEvent event = createSCMEvent(run, scmData);
+				OctaneSDK.getInstance().getEventsService().publishEvent(event);
+			}
+		} catch (Throwable throwable) {
+			logger.error("failed to build and/or dispatch SCM event for " + run, throwable);
 		}
 	}
 

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/WorkflowListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/WorkflowListenerOctaneImpl.java
@@ -16,7 +16,6 @@
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
- *
  */
 
 package com.microfocus.application.automation.tools.octane.events;
@@ -67,14 +66,18 @@ public class WorkflowListenerOctaneImpl implements GraphListener {
 
 	@Override
 	public void onNewHead(FlowNode flowNode) {
-		if (BuildHandlerUtils.isWorkflowStartNode(flowNode)) {
-			sendPipelineStartedEvent(flowNode);
-		} else if (BuildHandlerUtils.isWorkflowEndNode(flowNode)) {
-			sendPipelineFinishedEvent((FlowEndNode) flowNode);
-		} else if (BuildHandlerUtils.isStageStartNode(flowNode)) {
-			sendStageStartedEvent((StepStartNode) flowNode);
-		} else if (BuildHandlerUtils.isStageEndNode(flowNode)) {
-			sendStageFinishedEvent((StepEndNode) flowNode);
+		try {
+			if (BuildHandlerUtils.isWorkflowStartNode(flowNode)) {
+				sendPipelineStartedEvent(flowNode);
+			} else if (BuildHandlerUtils.isWorkflowEndNode(flowNode)) {
+				sendPipelineFinishedEvent((FlowEndNode) flowNode);
+			} else if (BuildHandlerUtils.isStageStartNode(flowNode)) {
+				sendStageStartedEvent((StepStartNode) flowNode);
+			} else if (BuildHandlerUtils.isStageEndNode(flowNode)) {
+				sendStageFinishedEvent((StepEndNode) flowNode);
+			}
+		} catch (Throwable throwable) {
+			logger.error("failed to build and/or dispatch STARTED/FINISHED event for " + flowNode, throwable);
 		}
 	}
 


### PR DESCRIPTION
Any failure in our plugin's events processing flow should NOT affect the continuation of the build, since none of those failures are mission-critical one.
[JENKINS-53873](https://issues.jenkins-ci.org/browse/JENKINS-53873)