### PR TITLE
defect #710074 : uft discovery - localized tests name on Octane not shown correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,7 +449,7 @@
 		<dependency>
 			<artifactId>integrations-sdk</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.5.33</version>
+			<version>1.5.36</version>
 		</dependency>
 
 		<!-- Obsolete TO BE REMOVED -->


### PR DESCRIPTION
defect #710074 : uft discovery - localized tests name on Octane not shown correctly
[JENKINS-53940](https://issues.jenkins-ci.org/browse/JENKINS-53940)