### PR TITLE
JENKINS-54696 - handle Octane's 502 as temporary error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,7 +443,7 @@
 		<dependency>
 			<artifactId>integrations-sdk</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>2.0.19</version>
+			<version>2.0.21</version>
 		</dependency>
 
 		<!--BUILDER providers integration-->


### PR DESCRIPTION
Octane's responses 502 should be treated as temporary error and handled with retying logic

[JENKINS-54696](https://issues.jenkins-ci.org/browse/JENKINS-54696)

