### PR TITLE
Uft discovery job is not working correctly in Jenkins 2.107.1+ because of Security hardening

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,7 +443,7 @@
 		<dependency>
 			<artifactId>integrations-sdk</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>2.0.24</version>
+			<version>2.0.25</version>
 		</dependency>
 
 		<!--BUILDER providers integration-->

--- a/src/main/java/com/microfocus/application/automation/tools/octane/executor/UftTestDiscoveryDispatcher.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/executor/UftTestDiscoveryDispatcher.java
@@ -182,9 +182,9 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
 			if (!subWorkspace.exists()) {
 				subWorkspace.mkdirs();
 			}
-			File reportXmlFile = new File(subWorkspace.getRemote(), "final_detection_result_build_" + item.getBuildNumber() + ".xml");
+			File reportXmlFile = new File(subWorkspace.getRemote(), "final_detection_result_build_" + item.getBuildNumber() + ".json");
 			result.writeToFile(reportXmlFile);
-		} catch (IOException | InterruptedException | JAXBException e) {
+		} catch (IOException | InterruptedException e) {
 			logger.error("Failed to write final_detection_result file :" + e.getMessage());
 		}
 

--- a/src/main/resources/com/microfocus/application/automation/tools/octane/actions/UFTTestDetectionBuildAction/index.jelly
+++ b/src/main/resources/com/microfocus/application/automation/tools/octane/actions/UFTTestDetectionBuildAction/index.jelly
@@ -196,7 +196,7 @@
 
         <br/><br/><br/>
 
-        This report contains items that were discovered in SCM repository. Final list of  dispatched items can be found <a href="../../ws/_Final_Detection_Results/final_detection_result_build_${it.build.id}.xml">here</a> after dispatching.
+        This report contains items that were discovered in SCM repository. Final list of  dispatched items can be found <a href="../../ws/_Final_Detection_Results/final_detection_result_build_${it.build.id}.json">here</a> after dispatching.
 
 
     </l:main-panel>


### PR DESCRIPTION
[JENKINS-55367 : Uft discovery job is not working correctly in Jenkins 2.107.1+ because of Security hardening](https://issues.jenkins-ci.org/browse/JENKINS-55367)