### PR TITLE
tech: fixing premature logs initialization (which, when done before S…

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/octane/CIJenkinsServicesImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/CIJenkinsServicesImpl.java
@@ -48,6 +48,7 @@ import com.hp.octane.integrations.exceptions.PermissionException;
 import com.microfocus.application.automation.tools.model.OctaneServerSettingsModel;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigurationService;
 import com.microfocus.application.automation.tools.octane.configuration.FodConfigUtil;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.configuration.SSCServerConfigUtil;
 import com.microfocus.application.automation.tools.octane.executor.ExecutorConnectivityService;
 import com.microfocus.application.automation.tools.octane.executor.TestExecutionJobCreatorService;
@@ -70,7 +71,6 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.xml.bind.DatatypeConverter;
@@ -90,7 +90,7 @@ import java.util.stream.Collectors;
  */
 
 public class CIJenkinsServicesImpl extends CIPluginServices {
-	private static final Logger logger = LogManager.getLogger(CIJenkinsServicesImpl.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(CIJenkinsServicesImpl.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	@Override

--- a/src/main/java/com/microfocus/application/automation/tools/octane/ImpersonationUtil.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/ImpersonationUtil.java
@@ -24,10 +24,10 @@ package com.microfocus.application.automation.tools.octane;
 import com.hp.octane.integrations.exceptions.PermissionException;
 import com.microfocus.application.automation.tools.model.OctaneServerSettingsModel;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigurationService;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
@@ -37,8 +37,7 @@ import java.util.Collections;
  */
 
 public class ImpersonationUtil {
-
-    private static final Logger logger = LogManager.getLogger(ImpersonationUtil.class);
+    private static final Logger logger = SDKBasedLoggerProvider.getLogger(ImpersonationUtil.class);
 
     public static ACLContext startImpersonation(String instanceId) {
         OctaneServerSettingsModel settings = ConfigurationService.getSettings(instanceId);

--- a/src/main/java/com/microfocus/application/automation/tools/octane/actions/UFTTestDetectionPublisher.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/actions/UFTTestDetectionPublisher.java
@@ -30,6 +30,7 @@ import com.hp.octane.integrations.uft.items.UftTestDiscoveryResult;
 import com.microfocus.application.automation.tools.model.OctaneServerSettingsModel;
 import com.microfocus.application.automation.tools.octane.Messages;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigurationService;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.executor.UFTTestDetectionService;
 import com.microfocus.application.automation.tools.octane.executor.UftJobRecognizer;
 import hudson.Extension;
@@ -42,7 +43,6 @@ import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -57,11 +57,10 @@ import java.util.List;
  */
 
 public class UFTTestDetectionPublisher extends Recorder {
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(UFTTestDetectionPublisher.class);
 	private String configurationId;
 	private String workspaceName;
 	private String scmRepositoryId;
-
-	private static final Logger logger = LogManager.getLogger(UFTTestDetectionPublisher.class);
 
 	public String getWorkspaceName() {
 		return workspaceName;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/actions/Webhooks.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/actions/Webhooks.java
@@ -26,6 +26,7 @@ import com.hp.octane.integrations.services.vulnerabilities.ToolType;
 import com.microfocus.application.automation.tools.octane.ImpersonationUtil;
 import com.microfocus.application.automation.tools.model.OctaneServerSettingsModel;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigurationService;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.SonarHelper;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigApi;
 import hudson.Extension;
@@ -37,7 +38,6 @@ import jenkins.model.Jenkins;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -57,184 +57,183 @@ import java.util.Map;
 
 @Extension
 public class Webhooks implements UnprotectedRootAction {
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(Webhooks.class);
+	// url details
+	public static final String WEBHOOK_PATH = "webhooks";
+	public static final String NOTIFY_METHOD = "/notify";
 
+	private String PROJECT_KEY_KEY = "PROJECT_KEY";
+	private String SONAR_URL_KEY = "SONAR_URL";
+	private String SONAR_TOKEN_KEY = "SONAR_TOKEN";
+	private String REMOTE_TAG_KEY = "REMOTE_TAG";
 
-    private static final Logger logger = LogManager.getLogger(Webhooks.class);
-    // url details
-    public static final String WEBHOOK_PATH = "webhooks";
-    public static final String NOTIFY_METHOD = "/notify";
+	// json parameter names
+	private final String PROJECT = "project";
+	private final String SONAR_PROJECT_KEY_NAME = "key";
+	private final String IS_EXPECTING_FILE_NAME = "is_expecting.txt";
+	private final String JOB_NAME_PARAM_NAME = "sonar.analysis.jobName";
+	private final String BUILD_NUMBER_PARAM_NAME = "sonar.analysis.buildNumber";
+	private static final String PROJECT_KEY_HEADER = "X-SonarQube-Project";
 
-    private String PROJECT_KEY_KEY = "PROJECT_KEY";
-    private String SONAR_URL_KEY = "SONAR_URL";
-    private String SONAR_TOKEN_KEY = "SONAR_TOKEN";
-    private String REMOTE_TAG_KEY = "REMOTE_TAG";
+	public String getIconFileName() {
+		return null;
+	}
 
-    // json parameter names
-    private final String PROJECT = "project";
-    private final String SONAR_PROJECT_KEY_NAME = "key";
-    private final String IS_EXPECTING_FILE_NAME = "is_expecting.txt";
-    private final String JOB_NAME_PARAM_NAME = "sonar.analysis.jobName";
-    private final String BUILD_NUMBER_PARAM_NAME = "sonar.analysis.buildNumber";
-    private static final String PROJECT_KEY_HEADER = "X-SonarQube-Project";
+	public String getDisplayName() {
+		return null;
+	}
 
-    public String getIconFileName() {
-        return null;
-    }
+	public String getUrlName() {
+		return WEBHOOK_PATH;
+	}
 
-    public String getDisplayName() {
-        return null;
-    }
+	public ConfigApi getConfiguration() {
+		return new ConfigApi();
+	}
 
-    public String getUrlName() {
-        return WEBHOOK_PATH;
-    }
+	@RequirePOST
+	public void doNotify(StaplerRequest req, StaplerResponse res) throws IOException {
+		logger.info("Received POST from " + req.getRemoteHost());
+		// legal user, handle request
+		JSONObject inputNotification = (JSONObject) JSONValue.parse(req.getInputStream());
+		Object properties = inputNotification.get("properties");
+		// without build context, could not send octane relevant data
+		if (!req.getHeader(PROJECT_KEY_HEADER).isEmpty() && properties instanceof Map) {
+			// get relevant parameters
+			Map sonarAttachedProperties = (Map) properties;
+			// filter notifications from sonar projects, who haven't configured listener parameters
+			if (sonarAttachedProperties.containsKey(BUILD_NUMBER_PARAM_NAME) && sonarAttachedProperties.containsKey(JOB_NAME_PARAM_NAME)) {
+				String buildId = (String) (sonarAttachedProperties.get(BUILD_NUMBER_PARAM_NAME));
+				String jobName = (String) sonarAttachedProperties.get(JOB_NAME_PARAM_NAME);
+				Run run = null;
+				for (OctaneClient octaneClient : OctaneSDK.getClients()) {
+					ACLContext aclContext = null;
+					try {
+						String octaneInstanceId = octaneClient.getInstanceId();
+						aclContext = ImpersonationUtil.startImpersonation(octaneInstanceId);
+						TopLevelItem topLevelItem = Jenkins.getInstance().getItem(jobName);
+						if (isValidJenkinsJob(topLevelItem)) {
+							Job jenkinsJob = ((Job) topLevelItem);
+							Integer buildNumber = Integer.valueOf(buildId, 10);
+							if (isValidJenkinsBuildNumber(jenkinsJob, buildNumber)) {
+								run = getRun(jenkinsJob, buildNumber);
+								if (run != null && isRunExpectingToGetWebhookCall(run) && !isRunAlreadyGotWebhookCall(run)) {
+									WebhookAction action = run.getAction(WebhookAction.class);
+									ExtensionList<GlobalConfiguration> allConfigurations = GlobalConfiguration.all();
+									GlobalConfiguration sonarConfiguration = allConfigurations.getDynamic(SonarHelper.SONAR_GLOBAL_CONFIG);
+									if (sonarConfiguration != null) {
+										String sonarToken = SonarHelper.getSonarInstallationTokenByUrl(sonarConfiguration, action.getServerUrl());
+										HashMap project = (HashMap) inputNotification.get(PROJECT);
+										String sonarProjectKey = (String) project.get(SONAR_PROJECT_KEY_NAME);
 
-    public ConfigApi getConfiguration() {
-        return new ConfigApi();
-    }
+										if (action.getDataTypeSet().contains(SonarHelper.DataType.COVERAGE)) {
+											// use SDK to fetch and push data
+											octaneClient.getSonarService().enqueueFetchAndPushSonarCoverage(jobName, buildId, sonarProjectKey, action.getServerUrl(), sonarToken);
+										}
+										if (action.getDataTypeSet().contains(SonarHelper.DataType.VULNERABILITIES)) {
+											Map<String, String> additionalProperties = new HashMap<>();
+											additionalProperties.put(PROJECT_KEY_KEY, sonarProjectKey);
+											additionalProperties.put(SONAR_URL_KEY, action.getServerUrl());
+											additionalProperties.put(SONAR_TOKEN_KEY, sonarToken);
+											additionalProperties.put(REMOTE_TAG_KEY, sonarProjectKey);
+											OctaneServerSettingsModel settings = ConfigurationService.getSettings(octaneInstanceId);
+											octaneClient.getVulnerabilitiesService().enqueueRetrieveAndPushVulnerabilities(jobName, buildId, ToolType.SONAR, run.getStartTimeInMillis(), settings.getMaxTimeoutHours(), additionalProperties);
 
-    @RequirePOST
-    public void doNotify(StaplerRequest req, StaplerResponse res) throws IOException {
-        logger.info("Received POST from " + req.getRemoteHost());
-        // legal user, handle request
-        JSONObject inputNotification = (JSONObject) JSONValue.parse(req.getInputStream());
-        Object properties = inputNotification.get("properties");
-        // without build context, could not send octane relevant data
-        if (!req.getHeader(PROJECT_KEY_HEADER).isEmpty() && properties instanceof Map) {
-            // get relevant parameters
-            Map sonarAttachedProperties = (Map) properties;
-            // filter notifications from sonar projects, who haven't configured listener parameters
-            if (sonarAttachedProperties.containsKey(BUILD_NUMBER_PARAM_NAME) && sonarAttachedProperties.containsKey(JOB_NAME_PARAM_NAME)) {
-                String buildId = (String) (sonarAttachedProperties.get(BUILD_NUMBER_PARAM_NAME));
-                String jobName = (String) sonarAttachedProperties.get(JOB_NAME_PARAM_NAME);
-                Run run = null;
-                for (OctaneClient octaneClient : OctaneSDK.getClients()) {
-                    ACLContext aclContext = null;
-                    try{
-                        String octaneInstanceId = octaneClient.getInstanceId();
-                        aclContext = ImpersonationUtil.startImpersonation(octaneInstanceId);
-                        TopLevelItem topLevelItem = Jenkins.getInstance().getItem(jobName);
-                        if (isValidJenkinsJob(topLevelItem)) {
-                            Job jenkinsJob = ((Job) topLevelItem);
-                            Integer buildNumber = Integer.valueOf(buildId, 10);
-                            if (isValidJenkinsBuildNumber(jenkinsJob, buildNumber)) {
-                                run = getRun(jenkinsJob, buildNumber);
-                                if (run != null && isRunExpectingToGetWebhookCall(run) && !isRunAlreadyGotWebhookCall(run)) {
-                                    WebhookAction action = run.getAction(WebhookAction.class);
-                                    ExtensionList<GlobalConfiguration> allConfigurations = GlobalConfiguration.all();
-                                    GlobalConfiguration sonarConfiguration = allConfigurations.getDynamic(SonarHelper.SONAR_GLOBAL_CONFIG);
-                                    if (sonarConfiguration != null) {
-                                        String sonarToken = SonarHelper.getSonarInstallationTokenByUrl(sonarConfiguration, action.getServerUrl());
-                                        HashMap project = (HashMap) inputNotification.get(PROJECT);
-                                        String sonarProjectKey = (String) project.get(SONAR_PROJECT_KEY_NAME);
+										}
+										res.setStatus(HttpStatus.SC_OK); // sonar should get positive feedback for webhook
+									}
+								} else {
+									logger.warn("Got request from sonarqube webhook listener for build ," + buildId + " which is not expecting to get sonarqube data");
+									res.setStatus(HttpStatus.SC_EXPECTATION_FAILED);
+								}
+							} else {
+								logger.warn("Got request from sonarqube webhook listener, but build " + buildId + " context could not be resolved");
+								res.setStatus(HttpStatus.SC_NOT_ACCEPTABLE);
+							}
+						}
+					} catch (Exception e) {
+						logger.error("exception occurred while trying to enqueue fetchAndPush task to octane, for build: " + buildId, e);
+					} finally {
+						if (aclContext != null) {
+							ImpersonationUtil.stopImpersonation(aclContext);
+						}
+					}
+				}
+				if (run != null) {
+					markBuildAsRecievedWebhookCall(run);
+				}
+			}
+		}
+	}
 
-                                        if (action.getDataTypeSet().contains(SonarHelper.DataType.COVERAGE)) {
-                                            // use SDK to fetch and push data
-                                            octaneClient.getSonarService().enqueueFetchAndPushSonarCoverage(jobName, buildId, sonarProjectKey, action.getServerUrl(), sonarToken);
-                                        }
-                                        if (action.getDataTypeSet().contains(SonarHelper.DataType.VULNERABILITIES)) {
-                                            Map<String, String> additionalProperties = new HashMap<>();
-                                            additionalProperties.put(PROJECT_KEY_KEY, sonarProjectKey);
-                                            additionalProperties.put(SONAR_URL_KEY, action.getServerUrl());
-                                            additionalProperties.put(SONAR_TOKEN_KEY, sonarToken);
-                                            additionalProperties.put(REMOTE_TAG_KEY, sonarProjectKey);
-                                            OctaneServerSettingsModel settings = ConfigurationService.getSettings(octaneInstanceId);
-                                            octaneClient.getVulnerabilitiesService().enqueueRetrieveAndPushVulnerabilities(jobName, buildId, ToolType.SONAR, run.getStartTimeInMillis(), settings.getMaxTimeoutHours(), additionalProperties);
+	/**
+	 * this method checks if run already got webhook call.
+	 * we are only handling the first call, laters call for the same run
+	 * will be rejected
+	 *
+	 * @param run run
+	 * @return result
+	 */
+	private Boolean isRunAlreadyGotWebhookCall(Run run) {
+		try {
+			// run is promised to be exist at this point
+			File rootDir = run.getRootDir();
+			File isExpectingFile = new File(rootDir, IS_EXPECTING_FILE_NAME);
+			FileInputStream fis = new FileInputStream(isExpectingFile);
+			ObjectInputStream ois = new ObjectInputStream(fis);
+			return (Boolean) ois.readObject();
+		} catch (Exception e) {
+			return Boolean.FALSE;
+		}
+	}
 
-                                        }
-                                        res.setStatus(HttpStatus.SC_OK); // sonar should get positive feedback for webhook
-                                    }
-                                } else {
-                                    logger.warn("Got request from sonarqube webhook listener for build ," + buildId + " which is not expecting to get sonarqube data");
-                                    res.setStatus(HttpStatus.SC_EXPECTATION_FAILED);
-                                }
-                            } else {
-                                logger.warn("Got request from sonarqube webhook listener, but build " + buildId + " context could not be resolved");
-                                res.setStatus(HttpStatus.SC_NOT_ACCEPTABLE);
-                            }
-                        }
-                    }catch (Exception e ){
-                        logger.error("exception occurred while trying to enqueue fetchAndPush task to octane, for build: " + buildId , e);
-                    }finally {
-                        if (aclContext != null ){
-                            ImpersonationUtil.stopImpersonation(aclContext);
-                        }
-                    }
-                }
-                if (run != null){
-                    markBuildAsRecievedWebhookCall(run);
-                }
-            }
-        }
-    }
-    /**
-     * this method checks if run already got webhook call.
-     * we are only handling the first call, laters call for the same run
-     * will be rejected
-     *
-     * @param run run
-     * @return result
-     */
-    private Boolean isRunAlreadyGotWebhookCall(Run run) {
-        try {
-            // run is promised to be exist at this point
-            File rootDir = run.getRootDir();
-            File isExpectingFile = new File(rootDir, IS_EXPECTING_FILE_NAME);
-            FileInputStream fis = new FileInputStream(isExpectingFile);
-            ObjectInputStream ois = new ObjectInputStream(fis);
-            return (Boolean) ois.readObject();
-        } catch (Exception e) {
-            return Boolean.FALSE;
-        }
-    }
+	/**
+	 * use build action to decide whether we need to get a webhook call from sonarqube
+	 *
+	 * @param run build
+	 * @return true or false
+	 */
+	private Boolean isRunExpectingToGetWebhookCall(Run run) {
+		WebhookAction action = run.getAction(WebhookAction.class);
+		return action != null && action.getExpectingToGetWebhookCall();
+	}
 
-    /**
-     * use build action to decide whether we need to get a webhook call from sonarqube
-     *
-     * @param run build
-     * @return true or false
-     */
-    private Boolean isRunExpectingToGetWebhookCall(Run run) {
-        WebhookAction action = run.getAction(WebhookAction.class);
-        return action != null && action.getExpectingToGetWebhookCall();
-    }
+	// we may get notifications from sonar project of jobs without sonar configuration
+	// or jobs of other CI servers, using this method, we ignore these notifications
+	private boolean isValidJenkinsJob(TopLevelItem jenkinsJob) {
+		return jenkinsJob instanceof Job;
+	}
 
-    // we may get notifications from sonar project of jobs without sonar configuration
-    // or jobs of other CI servers, using this method, we ignore these notifications
-    private boolean isValidJenkinsJob(TopLevelItem jenkinsJob) {
-        return jenkinsJob instanceof Job;
-    }
+	// get run by build number and jenkins job
+	private Run getRun(Job jenkinsJob, int buildNumber) {
+		return jenkinsJob.getBuildByNumber(buildNumber);
+	}
 
-    // get run by build number and jenkins job
-    private Run getRun(Job jenkinsJob, int buildNumber) {
-        return jenkinsJob.getBuildByNumber(buildNumber);
-    }
+	// we may get notifications from sonar project of jobs without sonar configuration
+	// or jobs of other CI servers, using this method, we ignore these notifications
+	private boolean isValidJenkinsBuildNumber(Job jenkinsJob, Integer buildNumber) {
+		// in jenkins, all build ids are numbers
+		try {
+			return getRun(jenkinsJob, buildNumber) != null;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
 
-    // we may get notifications from sonar project of jobs without sonar configuration
-    // or jobs of other CI servers, using this method, we ignore these notifications
-    private boolean isValidJenkinsBuildNumber(Job jenkinsJob, Integer buildNumber) {
-        // in jenkins, all build ids are numbers
-        try {
-            return getRun(jenkinsJob, buildNumber) != null;
-        } catch (NumberFormatException e) {
-            return false;
-        }
-    }
-
-    /**
-     * this method persist the fact a specific run got webhook call.
-     *
-     * @param run run
-     * @throws IOException exception
-     */
-    private void markBuildAsRecievedWebhookCall(Run run) throws IOException {
-        if (run == null) {
-            return;
-        }
-        File buildBaseFolder = run.getRootDir();
-        File isExpectingFile = new File(buildBaseFolder, IS_EXPECTING_FILE_NAME);
-        FileOutputStream fos = new FileOutputStream(isExpectingFile);
-        ObjectOutputStream oos = new ObjectOutputStream(fos);
-        oos.writeObject(true);
-    }
+	/**
+	 * this method persist the fact a specific run got webhook call.
+	 *
+	 * @param run run
+	 * @throws IOException exception
+	 */
+	private void markBuildAsRecievedWebhookCall(Run run) throws IOException {
+		if (run == null) {
+			return;
+		}
+		File buildBaseFolder = run.getRootDir();
+		File isExpectingFile = new File(buildBaseFolder, IS_EXPECTING_FILE_NAME);
+		FileOutputStream fos = new FileOutputStream(isExpectingFile);
+		ObjectOutputStream oos = new ObjectOutputStream(fos);
+		oos.writeObject(true);
+	}
 }

--- a/src/main/java/com/microfocus/application/automation/tools/octane/buildLogs/RunListenerForLogs.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/buildLogs/RunListenerForLogs.java
@@ -23,11 +23,11 @@ package com.microfocus.application.automation.tools.octane.buildLogs;
 import com.hp.octane.integrations.OctaneSDK;
 import com.microfocus.application.automation.tools.model.OctaneServerSettingsModel;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigurationService;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.Extension;
 import hudson.model.Run;
 import hudson.model.listeners.RunListener;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.Logger;
 
 @Extension
 public class RunListenerForLogs extends RunListener<Run> {
-	private static Logger logger = LogManager.getLogger(RunListenerForLogs.class);
+	private static Logger logger = SDKBasedLoggerProvider.getLogger(RunListenerForLogs.class);
 
 	@Override
 	public void onFinalized(Run run) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/configuration/ConfigApi.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/configuration/ConfigApi.java
@@ -27,7 +27,6 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -42,7 +41,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class ConfigApi {
-	private static final Logger logger = LogManager.getLogger(ConfigApi.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(ConfigApi.class);
 
 	public void doRead(StaplerRequest req, StaplerResponse res) throws ServletException, IOException {
 		checkPermission();

--- a/src/main/java/com/microfocus/application/automation/tools/octane/configuration/ConfigurationValidator.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/configuration/ConfigurationValidator.java
@@ -36,7 +36,6 @@ import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
@@ -47,7 +46,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class ConfigurationValidator {
-    private final static Logger logger = LogManager.getLogger(ConfigurationValidator.class);
+    private final static Logger logger = SDKBasedLoggerProvider.getLogger(ConfigurationValidator.class);
 
     private static final String PARAM_SHARED_SPACE = "p"; // NON-NLS
 

--- a/src/main/java/com/microfocus/application/automation/tools/octane/configuration/FodConfigUtil.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/configuration/FodConfigUtil.java
@@ -29,7 +29,6 @@ import hudson.tasks.Publisher;
 import jenkins.model.Jenkins;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
@@ -42,7 +41,7 @@ import static com.microfocus.application.automation.tools.octane.configuration.R
  * in Jenkins: URL, connection params, releaseId etc.
  */
 public class FodConfigUtil {
-    private final static Logger logger = LogManager.getLogger(FodConfigUtil.class);
+    private final static Logger logger = SDKBasedLoggerProvider.getLogger(FodConfigUtil.class);
 
     public final static String FOD_DESCRIPTOR = "org.jenkinsci.plugins.fodupload.FodGlobalDescriptor";
     public final static String FOD_STATIC_ASSESSMENT_STEP = "org.jenkinsci.plugins.fodupload.StaticAssessmentBuildStep";

--- a/src/main/java/com/microfocus/application/automation/tools/octane/configuration/JobConfigurationProxy.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/configuration/JobConfigurationProxy.java
@@ -44,7 +44,6 @@ import hudson.model.Job;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
@@ -57,7 +56,7 @@ import java.util.stream.Collectors;
  * This class is a proxy between JS UI code and server-side job configuration.
  */
 public class JobConfigurationProxy {
-	private final static Logger logger = LogManager.getLogger(JobConfigurationProxy.class);
+	private final static Logger logger = SDKBasedLoggerProvider.getLogger(JobConfigurationProxy.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	final private Job job;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/configuration/PredefinedConfigurationUnmarshaller.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/configuration/PredefinedConfigurationUnmarshaller.java
@@ -22,7 +22,6 @@ package com.microfocus.application.automation.tools.octane.configuration;
 
 import hudson.Extension;
 import jenkins.model.Jenkins;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.xml.bind.JAXBContext;
@@ -33,7 +32,7 @@ import java.util.List;
 
 @Extension
 public final class PredefinedConfigurationUnmarshaller {
-	private final static Logger logger = LogManager.getLogger(PredefinedConfigurationUnmarshaller.class);
+	private final static Logger logger = SDKBasedLoggerProvider.getLogger(PredefinedConfigurationUnmarshaller.class);
 
 	private static PredefinedConfigurationUnmarshaller extensionInstance;
 	private static Unmarshaller jaxbUnmarshaller;
@@ -41,7 +40,7 @@ public final class PredefinedConfigurationUnmarshaller {
 	public static synchronized PredefinedConfigurationUnmarshaller getExtensionInstance() {
 		List<PredefinedConfigurationUnmarshaller> extensions;
 		if (extensionInstance == null) {
-			extensions = Jenkins.getInstance().getExtensionList(PredefinedConfigurationUnmarshaller.class);
+			extensions = Jenkins.get().getExtensionList(PredefinedConfigurationUnmarshaller.class);
 			if (extensions.isEmpty()) {
 				logger.warn("PredefinedConfigurationUnmarshaller was not initialized properly");
 				return null;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/configuration/SDKBasedLoggerProvider.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/configuration/SDKBasedLoggerProvider.java
@@ -20,31 +20,25 @@
 
 package com.microfocus.application.automation.tools.octane.configuration;
 
+import jenkins.model.Jenkins;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.lang.reflect.Field;
+import java.io.File;
 
-/***
- * A utility class to help retrieving data from objects,
- * on whom we have no type data.
+/**
+ * SDK based (log4j brought by SDK) logger provider
+ * Main purpose of this custom logger provider is to ensure correct logs location configuration at the earliest point of the plugin initialization
+ * TODO: this method might become a part of an SPI interface of SDK's plugin services
  */
-public class ReflectionUtils {
-    private static final Logger logger = SDKBasedLoggerProvider.getLogger(ReflectionUtils.class);
-    public static <T>  T getFieldValue(Object someObject, String fieldName) {
-        for (Field field : someObject.getClass().getDeclaredFields()) {
-            field.setAccessible(true);
-            if (field.getName().equals(fieldName)) {
-                Object value = null;
-                try {
-                    value = field.get(someObject);
-                } catch (IllegalAccessException e) {
-                    logger.error("Failed to getFieldValue", e);
-                }
-                if (value != null) {
-                    return (T)value;
-                }
-            }
-        }
-        return null;
-    }
+public final class SDKBasedLoggerProvider {
+	private static volatile boolean sysParamConfigured = false;
+
+	public static Logger getLogger(Class<?> type) {
+		if (!sysParamConfigured) {
+			System.setProperty("octaneAllowedStorage", new File(Jenkins.get().getRootDir(), "userContent").getAbsolutePath() + File.separator);
+			sysParamConfigured = true;
+		}
+		return LogManager.getLogger(type);
+	}
 }

--- a/src/main/java/com/microfocus/application/automation/tools/octane/configuration/SSCServerConfigUtil.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/configuration/SSCServerConfigUtil.java
@@ -25,22 +25,18 @@ import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.tasks.Publisher;
 import jenkins.model.Jenkins;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Field;
-
-import static com.microfocus.application.automation.tools.octane.configuration.ReflectionUtils.getFieldValue;
 
 /*
     Utility to help retrieving the configuration of the SSC Server URL and SSC project/version pair
  */
 
 public class SSCServerConfigUtil {
-
-	private static final Logger logger = LogManager.getLogger(SSCServerConfigUtil.class);
-    public static final String PUBLISHER_NEW_NAME = "com.fortify.plugin.jenkins.FortifyPlugin";
-	public static final String PUBLISHER_OLD_VERSION = "com.fortify.plugin.jenkins.FPRPublisher";
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(SSCServerConfigUtil.class);
+	private static final String PUBLISHER_NEW_NAME = "com.fortify.plugin.jenkins.FortifyPlugin";
+	private static final String PUBLISHER_OLD_VERSION = "com.fortify.plugin.jenkins.FPRPublisher";
 
 	public static String getSSCServer() {
 		Descriptor sscDescriptor = getSSCDescriptor();
@@ -81,9 +77,9 @@ public class SSCServerConfigUtil {
 		logger.warn("Version seems to be 18.20.1071 or higher");
 		//18.20.1071 version.
 		Object uploadSSC = getFieldValueAsObj(fprPublisher, "uploadSSC");
-		if(uploadSSC == null){
+		if (uploadSSC == null) {
 			logger.warn("uploadSSC section was not found");
-		}else {
+		} else {
 			logger.warn("uploadSSC was found ");
 			projectName = getFieldValue(uploadSSC, "projectName");
 			projectVersion = getFieldValue(uploadSSC, "projectVersion");
@@ -112,6 +108,7 @@ public class SSCServerConfigUtil {
 		}
 		return null;
 	}
+
 	private static Object getFieldValueAsObj(Object someObject, String fieldName) {
 		for (Field field : someObject.getClass().getDeclaredFields()) {
 			field.setAccessible(true);
@@ -127,12 +124,12 @@ public class SSCServerConfigUtil {
 	}
 
 	private static Descriptor getSSCDescriptor() {
-		Descriptor publisher = Jenkins.getInstance().getDescriptorByName(PUBLISHER_OLD_VERSION);
-		if(publisher == null){
+		Descriptor publisher = Jenkins.get().getDescriptorByName(PUBLISHER_OLD_VERSION);
+		if (publisher == null) {
 			//18.20 version and above.
 			logger.debug("didn't find Old SSC FPRPublisher");
-			Descriptor plugin = Jenkins.getInstance().getDescriptorByName(PUBLISHER_NEW_NAME);
-			if(plugin == null){
+			Descriptor plugin = Jenkins.get().getDescriptorByName(PUBLISHER_NEW_NAME);
+			if (plugin == null) {
 				logger.debug("didn't find Fortify Plugin of 18.20 version and above");
 			}
 			return plugin;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/AbstractBuildListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/AbstractBuildListenerOctaneImpl.java
@@ -28,6 +28,7 @@ import com.hp.octane.integrations.dto.events.PhaseType;
 import com.hp.octane.integrations.dto.pipelines.PipelineNode;
 import com.hp.octane.integrations.dto.pipelines.PipelinePhase;
 import com.microfocus.application.automation.tools.octane.CIJenkinsServicesImpl;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.CIEventCausesFactory;
 import com.microfocus.application.automation.tools.octane.model.processors.parameters.ParameterProcessors;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
@@ -41,7 +42,6 @@ import hudson.model.*;
 import hudson.model.listeners.RunListener;
 import hudson.scm.SCM;
 import jenkins.model.Jenkins;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
@@ -57,7 +57,7 @@ import java.util.List;
 @Extension
 @SuppressWarnings({"squid:S2259", "squid:S1872", "squid:S1698", "squid:S1132"})
 public final class AbstractBuildListenerOctaneImpl extends RunListener<AbstractBuild> {
-	private static final Logger logger = LogManager.getLogger(AbstractBuildListenerOctaneImpl.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(AbstractBuildListenerOctaneImpl.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	@Inject

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/GlobalEventsListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/GlobalEventsListenerOctaneImpl.java
@@ -24,6 +24,7 @@ import com.hp.octane.integrations.OctaneSDK;
 import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.events.CIEvent;
 import com.hp.octane.integrations.dto.events.CIEventType;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.executor.UftTestDiscoveryDispatcher;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
 import com.microfocus.application.automation.tools.settings.OctaneServerSettingsBuilder;
@@ -31,7 +32,6 @@ import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.listeners.ItemListener;
 import jenkins.model.Jenkins;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
@@ -44,7 +44,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
 @Extension
 public class GlobalEventsListenerOctaneImpl extends ItemListener {
-	private static final Logger logger = LogManager.getLogger(GlobalEventsListenerOctaneImpl.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(GlobalEventsListenerOctaneImpl.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	@Override
@@ -71,8 +71,7 @@ public class GlobalEventsListenerOctaneImpl extends ItemListener {
 	@Override
 	public void onBeforeShutdown() {
 		OctaneSDK.getClients().forEach(OctaneSDK::removeClient);
-
-		UftTestDiscoveryDispatcher dispatcher = Jenkins.getInstance().getExtensionList(UftTestDiscoveryDispatcher.class).get(0);
+		UftTestDiscoveryDispatcher dispatcher = Jenkins.get().getExtensionList(UftTestDiscoveryDispatcher.class).get(0);
 		dispatcher.close();
 	}
 }

--- a/src/main/java/com/microfocus/application/automation/tools/octane/events/WorkflowListenerOctaneImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/events/WorkflowListenerOctaneImpl.java
@@ -28,13 +28,13 @@ import com.hp.octane.integrations.dto.events.MultiBranchType;
 import com.hp.octane.integrations.dto.events.PhaseType;
 import com.hp.octane.integrations.dto.snapshots.CIBuildResult;
 import com.microfocus.application.automation.tools.octane.CIJenkinsServicesImpl;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.CIEventCausesFactory;
 import com.microfocus.application.automation.tools.octane.model.processors.parameters.ParameterProcessors;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
 import com.microfocus.application.automation.tools.octane.tests.TestListener;
 import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.Extension;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.TimingAction;
@@ -60,7 +60,7 @@ import java.util.Set;
 
 @Extension
 public class WorkflowListenerOctaneImpl implements GraphListener {
-	private static final Logger logger = LogManager.getLogger(WorkflowListenerOctaneImpl.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(WorkflowListenerOctaneImpl.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	//After upgrading Pipeline:Groovy plugin to Version 2.64: receive two start events, therefore

--- a/src/main/java/com/microfocus/application/automation/tools/octane/executor/ExecutorConnectivityService.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/executor/ExecutorConnectivityService.java
@@ -32,6 +32,7 @@ import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.connectivity.OctaneResponse;
 import com.hp.octane.integrations.dto.executor.CredentialsInfo;
 import com.hp.octane.integrations.dto.executor.TestConnectivityInfo;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.executor.scmmanager.ScmPluginFactory;
 import com.microfocus.application.automation.tools.octane.executor.scmmanager.ScmPluginHandler;
 import hudson.model.Item;
@@ -40,20 +41,17 @@ import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-
 /**
  * Utility for handling connectivity with scm repositories
  */
 public class ExecutorConnectivityService {
-
-	private static final Logger logger = LogManager.getLogger(ExecutorConnectivityService.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(ExecutorConnectivityService.class);
 	private static final Map<Permission, String> requirePremissions = initRequirePremissions();
 	private static final Map<Permission, String> credentialsPremissions = initCredentialsPremissions();
 	private static final String PLUGIN_NAME = "Application Automation Tools";

--- a/src/main/java/com/microfocus/application/automation/tools/octane/executor/TestExecutionJobCreatorService.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/executor/TestExecutionJobCreatorService.java
@@ -32,6 +32,7 @@ import com.hp.octane.integrations.executor.TestsToRunFramework;
 import com.hp.octane.integrations.utils.SdkConstants;
 import com.microfocus.application.automation.tools.model.ResultsPublisherModel;
 import com.microfocus.application.automation.tools.octane.actions.UFTTestDetectionPublisher;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.executor.scmmanager.ScmPluginFactory;
 import com.microfocus.application.automation.tools.octane.executor.scmmanager.ScmPluginHandler;
 import com.microfocus.application.automation.tools.octane.testrunner.TestsToRunConverterBuilder;
@@ -46,7 +47,6 @@ import hudson.triggers.SCMTrigger;
 import jenkins.model.BuildDiscarder;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -66,9 +66,7 @@ import java.util.*;
  * This service is responsible to create jobs (discovery and execution) for execution process.
  */
 public class TestExecutionJobCreatorService {
-
-	private static final Logger logger = LogManager.getLogger(TestExecutionJobCreatorService.class);
-
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(TestExecutionJobCreatorService.class);
 
 	/**
 	 * Create (if needed) and run test execution

--- a/src/main/java/com/microfocus/application/automation/tools/octane/executor/UFTTestDetectionService.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/executor/UFTTestDetectionService.java
@@ -24,6 +24,7 @@ import com.hp.octane.integrations.uft.UftTestDiscoveryUtils;
 import com.hp.octane.integrations.uft.items.*;
 import com.hp.octane.integrations.utils.SdkConstants;
 import com.hp.octane.integrations.utils.SdkStringUtils;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.executor.scmmanager.ScmPluginFactory;
 import com.microfocus.application.automation.tools.octane.executor.scmmanager.ScmPluginHandler;
 import hudson.ExtensionList;
@@ -33,7 +34,6 @@ import hudson.scm.ChangeLogSet;
 import hudson.scm.EditType;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.reflect.FieldUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
@@ -44,7 +44,7 @@ import java.util.*;
  * Service is responsible to detect changes according to SCM change and to put it to queue of UftTestDiscoveryDispatcher
  */
 public class UFTTestDetectionService {
-    private static final Logger logger = LogManager.getLogger(UFTTestDetectionService.class);
+    private static final Logger logger = SDKBasedLoggerProvider.getLogger(UFTTestDetectionService.class);
     private static final String INITIAL_DETECTION_FILE = "INITIAL_DETECTION_FILE.txt";
     private static final String DETECTION_RESULT_FILE = "detection_result.json";
 

--- a/src/main/java/com/microfocus/application/automation/tools/octane/executor/UftJobCleaner.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/executor/UftJobCleaner.java
@@ -27,6 +27,7 @@ import com.hp.octane.integrations.dto.entities.EntityConstants;
 import com.hp.octane.integrations.services.entities.EntitiesService;
 import com.hp.octane.integrations.services.entities.QueryHelper;
 import com.microfocus.application.automation.tools.octane.actions.UFTTestDetectionPublisher;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.tests.AbstractSafeLoggingAsyncPeriodWork;
 import hudson.Extension;
 import hudson.model.FreeStyleProject;
@@ -34,12 +35,10 @@ import hudson.model.PeriodicWork;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.*;
-
 
 /**
  * This class cleans outdated test execution jobs that were not used more than 7 days.
@@ -47,8 +46,7 @@ import java.util.*;
  */
 @Extension
 public class UftJobCleaner extends AbstractSafeLoggingAsyncPeriodWork {
-
-    private static Logger logger = LogManager.getLogger(UftJobCleaner.class);
+    private static Logger logger = SDKBasedLoggerProvider.getLogger(UftJobCleaner.class);
 
     public UftJobCleaner() {
         super("Uft Job Cleaner");

--- a/src/main/java/com/microfocus/application/automation/tools/octane/executor/UftTestDiscoveryDispatcher.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/executor/UftTestDiscoveryDispatcher.java
@@ -31,6 +31,7 @@ import com.hp.octane.integrations.uft.UftTestDispatchUtils;
 import com.hp.octane.integrations.uft.items.*;
 import com.hp.octane.integrations.utils.SdkStringUtils;
 import com.microfocus.application.automation.tools.octane.ResultQueue;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.tests.AbstractSafeLoggingAsyncPeriodWork;
 import hudson.Extension;
 import hudson.FilePath;
@@ -41,10 +42,8 @@ import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.xml.bind.JAXBException;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
@@ -59,8 +58,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Extension
 public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
-
-	private final static Logger logger = LogManager.getLogger(UftTestDiscoveryDispatcher.class);
+	private final static Logger logger = SDKBasedLoggerProvider.getLogger(UftTestDiscoveryDispatcher.class);
 
 	private final static int MAX_DISPATCH_TRIALS = 5;
 	private static final String OCTANE_VERSION_SUPPORTING_TEST_RENAME = "12.60.3";
@@ -94,7 +92,7 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
 		try {
 			while ((item = queue.peekFirst()) != null) {
 
-				Job project = (Job) Jenkins.getInstance().getItemByFullName(item.getProjectName());
+				Job project = (Job) Jenkins.get().getItemByFullName(item.getProjectName());
 				if (project == null) {
 					logger.warn("Project [" + item.getProjectName() + "] no longer exists, pending discovered tests can't be submitted");
 					queue.remove();
@@ -174,7 +172,7 @@ public class UftTestDiscoveryDispatcher extends AbstractSafeLoggingAsyncPeriodWo
 		}
 
 		//publish final results
-		FreeStyleProject project = (FreeStyleProject) Jenkins.getInstance().getItemByFullName(item.getProjectName());
+		FreeStyleProject project = (FreeStyleProject) Jenkins.get().getItemByFullName(item.getProjectName());
 		FilePath subWorkspace = project.getWorkspace().child("_Final_Detection_Results");
 		try {
 			if (!subWorkspace.exists()) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/executor/scmmanager/GitPluginHandler.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/executor/scmmanager/GitPluginHandler.java
@@ -25,6 +25,7 @@ import com.hp.octane.integrations.dto.connectivity.OctaneResponse;
 import com.hp.octane.integrations.dto.executor.TestConnectivityInfo;
 import com.hp.octane.integrations.dto.scm.SCMRepository;
 import com.hp.octane.integrations.dto.scm.SCMType;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.EnvVars;
 import hudson.model.FreeStyleProject;
 import hudson.model.Job;
@@ -35,7 +36,6 @@ import hudson.plugins.git.extensions.impl.RelativeTargetDirectory;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.SCM;
 import org.apache.http.HttpStatus;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -45,8 +45,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class GitPluginHandler implements ScmPluginHandler {
-
-	private static final Logger logger = LogManager.getLogger(GitPluginHandler.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(GitPluginHandler.class);
 
 	@Override
 	public void setScmRepositoryInJob(SCMRepository scmRepository, String scmRepositoryCredentialsId, FreeStyleProject proj, boolean executorJob) throws IOException {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/CIEventCausesFactory.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/CIEventCausesFactory.java
@@ -23,6 +23,7 @@ package com.microfocus.application.automation.tools.octane.model;
 import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.causes.CIEventCause;
 import com.hp.octane.integrations.dto.causes.CIEventCauseType;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
 import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.model.Cause;
@@ -30,7 +31,6 @@ import hudson.model.InvisibleAction;
 import hudson.model.Run;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
@@ -52,7 +52,7 @@ import java.util.Set;
  */
 
 public final class CIEventCausesFactory {
-	private static final Logger logger = LogManager.getLogger(CIEventCausesFactory.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(CIEventCausesFactory.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	private CIEventCausesFactory() {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/CIEventFactory.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/CIEventFactory.java
@@ -24,6 +24,7 @@ import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.events.CIEvent;
 import com.hp.octane.integrations.dto.events.CIEventType;
 import com.hp.octane.integrations.dto.scm.SCMData;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.processors.scm.SCMProcessor;
 import com.microfocus.application.automation.tools.octane.model.processors.scm.SCMProcessors;
 import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
@@ -31,7 +32,6 @@ import hudson.matrix.MatrixConfiguration;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.scm.SCM;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
@@ -39,8 +39,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
  * Factory for creating ci event
  */
 public final class CIEventFactory {
-
-    private static final Logger logger = LogManager.getLogger(CIEventFactory.class);
+    private static final Logger logger = SDKBasedLoggerProvider.getLogger(CIEventFactory.class);
     private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
     private CIEventFactory(){

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/ModelFactory.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/ModelFactory.java
@@ -29,6 +29,7 @@ import com.hp.octane.integrations.dto.snapshots.CIBuildResult;
 import com.hp.octane.integrations.dto.snapshots.CIBuildStatus;
 import com.hp.octane.integrations.dto.snapshots.SnapshotNode;
 import com.hp.octane.integrations.dto.snapshots.SnapshotPhase;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.processors.parameters.ParameterProcessors;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.AbstractProjectProcessor;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
@@ -37,7 +38,6 @@ import com.microfocus.application.automation.tools.octane.model.processors.scm.S
 import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.model.*;
 import jenkins.model.Jenkins;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.*;
@@ -46,7 +46,7 @@ import java.util.*;
  * Created by lazara on 26/01/2016.
  */
 public class ModelFactory {
-	private static final Logger logger = LogManager.getLogger(ModelFactory.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(ModelFactory.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	public static PipelineNode createStructureItem(Job job) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/builders/AbstractBuilderProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/builders/AbstractBuilderProcessor.java
@@ -21,10 +21,10 @@
 package com.microfocus.application.automation.tools.octane.model.processors.builders;
 
 import com.hp.octane.integrations.dto.pipelines.PipelinePhase;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
 import hudson.model.Job;
 import hudson.tasks.Builder;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
@@ -35,7 +35,7 @@ import java.util.Set;
  * Base class for discovery/provisioning of an internal phases/steps of the specific Job
  */
 public abstract class AbstractBuilderProcessor {
-	private static final Logger logger = LogManager.getLogger(AbstractBuilderProcessor.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(AbstractBuilderProcessor.class);
 	protected ArrayList<PipelinePhase> phases = new ArrayList<>();
 
 	/**

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/builders/BuildTriggerProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/builders/BuildTriggerProcessor.java
@@ -20,12 +20,12 @@
 
 package com.microfocus.application.automation.tools.octane.model.processors.builders;
 
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.ModelFactory;
 import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.tasks.BuildTrigger;
 import hudson.tasks.Publisher;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
@@ -37,7 +37,7 @@ import java.util.Set;
  * Implementation for discovery/provisioning of an internal phases/steps of the specific Job in context of BuildTrigger
  */
 public class BuildTriggerProcessor extends AbstractBuilderProcessor {
-	private static final Logger logger = LogManager.getLogger(BuildTriggerProcessor.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(BuildTriggerProcessor.class);
 
 	public BuildTriggerProcessor(Publisher publisher, AbstractProject project, Set<Job> processedJobs) {
 		BuildTrigger t = (BuildTrigger) publisher;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/builders/MultiJobBuilderProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/builders/MultiJobBuilderProcessor.java
@@ -20,6 +20,7 @@
 
 package com.microfocus.application.automation.tools.octane.model.processors.builders;
 
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.ModelFactory;
 import com.tikal.jenkins.plugins.multijob.MultiJobBuilder;
 import com.tikal.jenkins.plugins.multijob.PhaseJobsConfig;
@@ -27,7 +28,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.tasks.Builder;
 import jenkins.model.Jenkins;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
@@ -38,7 +38,7 @@ import java.util.Set;
  * Implementation for discovery/provisioning of an internal phases/steps of the specific Job in context of MultiJob Plugin
  */
 class MultiJobBuilderProcessor extends AbstractBuilderProcessor {
-    private static final Logger logger = LogManager.getLogger(MultiJobBuilderProcessor.class);
+    private static final Logger logger = SDKBasedLoggerProvider.getLogger(MultiJobBuilderProcessor.class);
 
     MultiJobBuilderProcessor(Builder builder, Job job, Set<Job> processedJobs) {
         MultiJobBuilder b = (MultiJobBuilder) builder;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/builders/ParameterizedTriggerProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/builders/ParameterizedTriggerProcessor.java
@@ -20,6 +20,7 @@
 
 package com.microfocus.application.automation.tools.octane.model.processors.builders;
 
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.ModelFactory;
 import hudson.model.AbstractProject;
 import hudson.model.Job;
@@ -29,7 +30,6 @@ import hudson.plugins.parameterizedtrigger.BuildTriggerConfig;
 import hudson.plugins.parameterizedtrigger.TriggerBuilder;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ import java.util.Set;
  * Implementation for discovery/provisioning of an internal phases/steps of the specific Job in context of ParameterizedTrigger Plugin
  */
 public class ParameterizedTriggerProcessor extends AbstractBuilderProcessor {
-	private static final Logger logger = LogManager.getLogger(ParameterizedTriggerProcessor.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(ParameterizedTriggerProcessor.class);
 
 	ParameterizedTriggerProcessor(Builder builder, Job job, String phasesName, Set<Job> processedJobs) {
 		TriggerBuilder b = (TriggerBuilder) builder;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/parameters/ParameterProcessors.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/parameters/ParameterProcessors.java
@@ -23,10 +23,10 @@ package com.microfocus.application.automation.tools.octane.model.processors.para
 import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.parameters.CIParameter;
 import com.hp.octane.integrations.dto.parameters.CIParameterType;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.ModelFactory;
 import hudson.matrix.*;
 import hudson.model.*;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
@@ -48,7 +48,7 @@ public enum ParameterProcessors {
 	NODE_LABEL("org.jvnet.jenkins.plugins.nodelabelparameter", NodeLabelParameterProcessor.class),
 	RANDOM_STRING("hudson.plugins.random_string_parameter.RandomStringParameterDefinition", RandomStringParameterProcessor.class);
 
-	private static final Logger logger = LogManager.getLogger(ParameterProcessors.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(ParameterProcessors.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 	private String targetPluginClassName;
 	private Class<? extends AbstractParametersProcessor> processorClass;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/projects/AbstractProjectProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/projects/AbstractProjectProcessor.java
@@ -21,6 +21,7 @@
 package com.microfocus.application.automation.tools.octane.model.processors.projects;
 
 import com.hp.octane.integrations.dto.pipelines.PipelinePhase;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.executor.UftConstants;
 import com.microfocus.application.automation.tools.octane.model.processors.builders.AbstractBuilderProcessor;
 import com.microfocus.application.automation.tools.octane.model.processors.builders.BuildTriggerProcessor;
@@ -30,7 +31,6 @@ import hudson.model.*;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
 import jenkins.model.Jenkins;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ import java.util.Set;
 
 @SuppressWarnings({"squid:S1132", "squid:S1872"})
 public abstract class AbstractProjectProcessor<T extends Job> {
-	private static final Logger logger = LogManager.getLogger(AbstractProjectProcessor.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(AbstractProjectProcessor.class);
 	private final List<PipelinePhase> internals = new ArrayList<>();
 	private final List<PipelinePhase> postBuilds = new ArrayList<>();
 

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GenericSCMProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GenericSCMProcessor.java
@@ -26,6 +26,7 @@ import com.hp.octane.integrations.dto.scm.SCMCommit;
 import com.hp.octane.integrations.dto.scm.SCMData;
 import com.hp.octane.integrations.dto.scm.SCMRepository;
 import com.hp.octane.integrations.dto.scm.SCMType;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.User;
@@ -33,7 +34,6 @@ import hudson.model.UserProperty;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.SCM;
 import hudson.tasks.Mailer;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
@@ -45,7 +45,7 @@ import java.util.List;
  */
 
 class GenericSCMProcessor implements SCMProcessor {
-	private static final Logger logger = LogManager.getLogger(GenericSCMProcessor.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(GenericSCMProcessor.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 
 	@Override

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GitSCMProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/GitSCMProcessor.java
@@ -25,6 +25,7 @@ import com.hp.octane.integrations.dto.scm.*;
 import com.hp.octane.integrations.dto.scm.impl.LineRange;
 import com.hp.octane.integrations.dto.scm.impl.RevisionsMap;
 import com.hp.octane.integrations.dto.scm.impl.SCMFileBlameImpl;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.FilePath;
 import hudson.model.*;
 import hudson.plugins.git.Branch;
@@ -41,7 +42,6 @@ import hudson.scm.SCM;
 import hudson.tasks.Mailer;
 import hudson.util.DescribableList;
 import jenkins.MasterToSlaveFileCallable;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jgit.api.BlameCommand;
 import org.eclipse.jgit.api.Git;
@@ -69,7 +69,7 @@ import java.util.*;
  */
 
 class GitSCMProcessor implements SCMProcessor {
-    private static final Logger logger = LogManager.getLogger(GitSCMProcessor.class);
+    private static final Logger logger = SDKBasedLoggerProvider.getLogger(GitSCMProcessor.class);
     private static final DTOFactory dtoFactory = DTOFactory.getInstance();
     private static final String MASTER = "refs/remotes/origin/master";
 

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/SCMProcessors.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/SCMProcessors.java
@@ -20,8 +20,8 @@
 
 package com.microfocus.application.automation.tools.octane.model.processors.scm;
 
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.settings.OctaneServerSettingsBuilder;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
@@ -33,7 +33,7 @@ public enum SCMProcessors {
 	GIT("hudson.plugins.git.GitSCM", GitSCMProcessor.class),
 	SVN("hudson.scm.SubversionSCM", SvnSCMProcessor.class);
 
-	private static Logger logger = LogManager.getLogger(OctaneServerSettingsBuilder.class);
+	private static Logger logger = SDKBasedLoggerProvider.getLogger(OctaneServerSettingsBuilder.class);
 	private String targetSCMPluginClassName;
 	private Class<? extends SCMProcessor> processorClass;
 

--- a/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/SvnSCMProcessor.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/model/processors/scm/SvnSCMProcessor.java
@@ -26,6 +26,7 @@ import com.hp.octane.integrations.dto.scm.SCMCommit;
 import com.hp.octane.integrations.dto.scm.SCMData;
 import com.hp.octane.integrations.dto.scm.SCMRepository;
 import com.hp.octane.integrations.dto.scm.SCMType;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.model.*;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.SCM;
@@ -33,7 +34,6 @@ import hudson.scm.SVNRevisionState;
 import hudson.scm.SubversionChangeLogSet;
 import hudson.scm.SubversionSCM;
 import hudson.tasks.Mailer;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
@@ -47,7 +47,7 @@ import java.util.List;
  */
 
 class SvnSCMProcessor implements SCMProcessor {
-	private static final Logger logger = LogManager.getLogger(SvnSCMProcessor.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(SvnSCMProcessor.class);
 	private static final DTOFactory dtoFactory = DTOFactory.getInstance();
 	private static final int PARENT_COMMIT_INDEX = 1;
 

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/TestListener.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/TestListener.java
@@ -21,6 +21,7 @@
 package com.microfocus.application.automation.tools.octane.tests;
 
 import com.hp.octane.integrations.OctaneSDK;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
 import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import com.microfocus.application.automation.tools.octane.tests.detection.UFTExtension;
@@ -30,7 +31,6 @@ import hudson.FilePath;
 import hudson.model.Run;
 import hudson.tasks.Builder;
 import jenkins.model.Jenkins;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.xml.stream.XMLStreamException;
@@ -42,7 +42,7 @@ import java.util.List;
 @Extension
 @SuppressWarnings({"squid:S2699", "squid:S3658", "squid:S2259", "squid:S1872"})
 public class TestListener {
-	private static Logger logger = LogManager.getLogger(TestListener.class);
+	private static Logger logger = SDKBasedLoggerProvider.getLogger(TestListener.class);
 
 	private static final String STORMRUNNER_LOAD_TEST_RUNNER_CLASS = "StormTestRunner";
 	private static final String STORMRUNNER_FUNCTIONAL_TEST_RUNNER_CLASS = "RunFromSrfBuilder";
@@ -54,7 +54,7 @@ public class TestListener {
 		TestResultXmlWriter resultWriter = new TestResultXmlWriter(resultPath, run);
 		boolean success = true;
 		boolean hasTests = false;
-		String jenkinsRootUrl = Jenkins.getInstance().getRootUrl();
+		String jenkinsRootUrl = Jenkins.get().getRootUrl();
 		HPRunnerType hpRunnerType = HPRunnerType.NONE;
 		List<Builder> builders = JobProcessorFactory.getFlowProcessor(run.getParent()).tryGetBuilders();
 		if (builders != null) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/build/BuildHandlerUtils.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/build/BuildHandlerUtils.java
@@ -21,6 +21,7 @@
 package com.microfocus.application.automation.tools.octane.tests.build;
 
 import com.hp.octane.integrations.dto.snapshots.CIBuildResult;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
 import hudson.FilePath;
 import hudson.matrix.MatrixConfiguration;
@@ -29,7 +30,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import hudson.model.Run;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
@@ -51,7 +51,7 @@ import java.io.IOException;
  */
 
 public class BuildHandlerUtils {
-	private static final Logger logger = LogManager.getLogger(BuildHandlerUtils.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(BuildHandlerUtils.class);
 
 	public static BuildDescriptor getBuildType(Run<?, ?> run) {
 		for (BuildHandlerExtension ext : BuildHandlerExtension.all()) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/detection/ResultFieldsDetectionService.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/detection/ResultFieldsDetectionService.java
@@ -20,15 +20,15 @@
 
 package com.microfocus.application.automation.tools.octane.tests.detection;
 
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.model.Run;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
  * Service used for auto detection of test results global parameters like test-framework, testing-tool, etc.
  */
 public class ResultFieldsDetectionService {
-	private static Logger logger = LogManager.getLogger(ResultFieldsDetectionService.class);
+	private static Logger logger = SDKBasedLoggerProvider.getLogger(ResultFieldsDetectionService.class);
 
 	public ResultFields getDetectedFields(Run<?,?> build) throws InterruptedException {
 		for (ResultFieldsDetectionExtension ext : ResultFieldsDetectionExtension.all()) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/gherkin/GherkinTestExtension.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/gherkin/GherkinTestExtension.java
@@ -21,6 +21,7 @@
 package com.microfocus.application.automation.tools.octane.tests.gherkin;
 
 import com.microfocus.application.automation.tools.octane.actions.cucumber.CucumberTestResultsAction;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.tests.HPRunnerType;
 import com.microfocus.application.automation.tools.octane.tests.OctaneTestsExtension;
 import com.microfocus.application.automation.tools.octane.tests.TestProcessingException;
@@ -28,7 +29,6 @@ import com.microfocus.application.automation.tools.octane.tests.TestResultContai
 import com.microfocus.application.automation.tools.octane.tests.testResult.TestResult;
 import hudson.Extension;
 import hudson.model.Run;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
@@ -36,7 +36,7 @@ import java.util.List;
 
 @Extension
 public class GherkinTestExtension extends OctaneTestsExtension {
-	private static Logger logger = LogManager.getLogger(GherkinTestExtension.class);
+	private static Logger logger = SDKBasedLoggerProvider.getLogger(GherkinTestExtension.class);
 
 	@Override
 	public boolean supports(Run<?, ?> build) {

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/impl/ObjectStreamIterator.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/impl/ObjectStreamIterator.java
@@ -20,8 +20,8 @@
 
 package com.microfocus.application.automation.tools.octane.tests.impl;
 
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.FilePath;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedInputStream;
@@ -31,7 +31,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 public class ObjectStreamIterator<E> implements Iterator<E> {
-    private static Logger logger = LogManager.getLogger(ObjectStreamIterator.class);
+    private static Logger logger = SDKBasedLoggerProvider.getLogger(ObjectStreamIterator.class);
 
     private ObjectInputStream ois;
     private FilePath filePath;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/junit/JUnitExtension.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/junit/JUnitExtension.java
@@ -22,6 +22,7 @@ package com.microfocus.application.automation.tools.octane.tests.junit;
 
 import com.google.inject.Inject;
 import com.microfocus.application.automation.tools.octane.actions.cucumber.CucumberTestResultsAction;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.executor.CheckOutSubDirEnvContributor;
 import com.microfocus.application.automation.tools.octane.tests.HPRunnerType;
 import com.microfocus.application.automation.tools.octane.tests.OctaneTestsExtension;
@@ -38,7 +39,6 @@ import hudson.maven.MavenModuleSetBuild;
 import hudson.model.Run;
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.test.AbstractTestResultAction;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jenkinsci.remoting.Role;
 import org.jenkinsci.remoting.RoleChecker;
@@ -56,7 +56,7 @@ import java.util.*;
  */
 @Extension
 public class JUnitExtension extends OctaneTestsExtension {
-	private static Logger logger = LogManager.getLogger(JUnitExtension.class);
+	private static Logger logger = SDKBasedLoggerProvider.getLogger(JUnitExtension.class);
 
 	private static final String STORMRUNNER_LOAD = "StormRunner Load";
 	private static final String STORMRUNNER_FUNCTIONAL = "StormRunner Functional";

--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
@@ -24,11 +24,11 @@ import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.tests.Property;
 import com.hp.octane.integrations.dto.tests.TestSuite;
 import com.hp.octane.integrations.utils.SdkConstants;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.tests.HPRunnerType;
 import com.microfocus.application.automation.tools.octane.tests.xml.AbstractXmlIterator;
 import hudson.FilePath;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.xml.stream.XMLStreamException;
@@ -47,7 +47,7 @@ import java.util.*;
  * JUnit result parser and enricher according to HPRunnerType
  */
 public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
-	private static final Logger logger = LogManager.getLogger(JUnitXmlIterator.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(JUnitXmlIterator.class);
 
 	public static final String DASHBOARD_URL = "dashboardUrl";
 	private final FilePath workspace;

--- a/src/main/java/com/microfocus/application/automation/tools/octane/vulnerabilities/VulnerabilitiesListener.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/vulnerabilities/VulnerabilitiesListener.java
@@ -25,12 +25,12 @@ import com.hp.octane.integrations.services.vulnerabilities.ToolType;
 import com.microfocus.application.automation.tools.model.OctaneServerSettingsModel;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigurationService;
 import com.microfocus.application.automation.tools.octane.configuration.FodConfigUtil;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import com.microfocus.application.automation.tools.octane.configuration.SSCServerConfigUtil;
 import com.microfocus.application.automation.tools.octane.tests.build.BuildHandlerUtils;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.listeners.RunListener;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
@@ -43,7 +43,7 @@ import java.util.Map;
 @Extension
 @SuppressWarnings({"squid:S2699", "squid:S3658", "squid:S2259", "squid:S1872"})
 public class VulnerabilitiesListener extends RunListener<AbstractBuild> {
-	private static Logger logger = LogManager.getLogger(VulnerabilitiesListener.class);
+	private static Logger logger = SDKBasedLoggerProvider.getLogger(VulnerabilitiesListener.class);
 
 	@Override
 	public void onFinalized(AbstractBuild build) {

--- a/src/main/java/com/microfocus/application/automation/tools/settings/AlmServerSettingsBuilder.java
+++ b/src/main/java/com/microfocus/application/automation/tools/settings/AlmServerSettingsBuilder.java
@@ -26,10 +26,10 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.XmlFile;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -64,8 +64,7 @@ import net.sf.json.JSONObject;
  * @author Kohsuke Kawaguchi
  */
 public class AlmServerSettingsBuilder extends Builder {
-
-    private static final Logger logger = LogManager.getLogger(AlmServerSettingsBuilder.class);
+    private static final Logger logger = SDKBasedLoggerProvider.getLogger(AlmServerSettingsBuilder.class);
     
     @Override
     public DescriptorImpl getDescriptor() {

--- a/src/main/java/com/microfocus/application/automation/tools/settings/OctaneServerSettingsBuilder.java
+++ b/src/main/java/com/microfocus/application/automation/tools/settings/OctaneServerSettingsBuilder.java
@@ -28,6 +28,7 @@ import com.microfocus.application.automation.tools.octane.Messages;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigurationListener;
 import com.microfocus.application.automation.tools.octane.configuration.ConfigurationValidator;
 import com.microfocus.application.automation.tools.octane.configuration.MqmProject;
+import com.microfocus.application.automation.tools.octane.configuration.SDKBasedLoggerProvider;
 import hudson.CopyOnWrite;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -42,7 +43,6 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -56,7 +56,7 @@ import java.util.*;
  */
 
 public class OctaneServerSettingsBuilder extends Builder {
-	private static final Logger logger = LogManager.getLogger(OctaneServerSettingsBuilder.class);
+	private static final Logger logger = SDKBasedLoggerProvider.getLogger(OctaneServerSettingsBuilder.class);
 
 	@Override
 	public OctaneDescriptorImpl getDescriptor() {
@@ -64,7 +64,7 @@ public class OctaneServerSettingsBuilder extends Builder {
 	}
 
 	public static OctaneDescriptorImpl getOctaneSettingsManager() {
-		OctaneDescriptorImpl octaneDescriptor = Jenkins.getInstance().getDescriptorByType(OctaneDescriptorImpl.class);
+		OctaneDescriptorImpl octaneDescriptor = Jenkins.get().getDescriptorByType(OctaneDescriptorImpl.class);
 		if (octaneDescriptor == null) {
 			throw new IllegalStateException("failed to obtain Octane plugin descriptor");
 		}


### PR DESCRIPTION
We are experiencing from time to time plugin's initialization issues related to the ability to write to the log.

Logs location configured by SDK, which takes some of the relevant knowledge from the plugin's SPI implementation.
This is not enough for the cases, where plugin's own classes are using the same Log4J logger system, since those are initialized BEFORE the SDK's part.

This PR resolves this issue by plugin handling it's own logging configuration eagerly.