### PR TITLE
Fix Defect #1067549: On running a bdd pipeline that creates an injection xml with size > 30 MB - nothing happens and get out of memory error in logs

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/octane/tests/gherkin/GherkinTestResultsCollector.java
+++ b/src/main/java/com/microfocus/application/automation/tools/octane/tests/gherkin/GherkinTestResultsCollector.java
@@ -222,7 +222,7 @@ public class GherkinTestResultsCollector {
     private static void validateXMLVersion(Document doc) {
         String XML_VERSION = "1";
         NodeList featuresNodes = doc.getElementsByTagName("features");
-        if(featuresNodes.getLength() > 0) {
+        if(featuresNodes.item(0)!=null) {
             String versionAttr = ((Element) featuresNodes.item(0)).getAttribute("version");
             if (versionAttr == null || versionAttr.isEmpty() || versionAttr.compareTo(XML_VERSION) != 0) {
                 throw new IllegalArgumentException("\n********************************************************\n" +


### PR DESCRIPTION
Fix Defect #1067549: On running a bdd pipeline that creates an injection xml with size > 30 MB - nothing happens and get out of memory error in logs
